### PR TITLE
[Feat]集合場所一覧ページ実装

### DIFF
--- a/admin/next-project/seeft-admin/src/components/common/DeleteButton/DeleteButton.tsx
+++ b/admin/next-project/seeft-admin/src/components/common/DeleteButton/DeleteButton.tsx
@@ -1,0 +1,27 @@
+import clsx from 'clsx';
+import React from 'react';
+import { MdDeleteForever } from 'react-icons/md';
+
+interface Props {
+  className?: string;
+  onClick?: () => void;
+  children?: React.ReactNode;
+}
+
+function DeleteButton(props: Props): JSX.Element {
+  const className = (props.className ? ` ${props.className}` : '');
+  return (
+    <div className={clsx(className)}>
+      <div className='p-2 rounded-full hover:bg-accent-1' onClick={props.onClick}>
+        <div className='flex justify-items-center gap-4'>
+          <MdDeleteForever />
+          <p className='text-center text-sm text-emphasis'>
+            {props.children}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default DeleteButton;

--- a/admin/next-project/seeft-admin/src/components/common/DeleteButton/index.ts
+++ b/admin/next-project/seeft-admin/src/components/common/DeleteButton/index.ts
@@ -1,0 +1,1 @@
+export { default } from './DeleteButton';

--- a/admin/next-project/seeft-admin/src/components/common/EditButton/EditButton.tsx
+++ b/admin/next-project/seeft-admin/src/components/common/EditButton/EditButton.tsx
@@ -1,0 +1,27 @@
+import clsx from 'clsx';
+import React from 'react';
+import { MdEdit } from 'react-icons/md';
+
+interface Props {
+  className?: string;
+  onClick?: () => void;
+  children?: React.ReactNode;
+}
+
+function EditButton(props: Props): JSX.Element {
+  const className = (props.className ? ` ${props.className}` : '');
+  return (
+    <div className={clsx(className)}>
+      <div className='p-2 rounded-full hover:bg-accent-1' onClick={props.onClick}>
+        <div className='flex justify-items-center gap-4'>
+          <MdEdit />
+          <p className='text-center text-sm text-emphasis'>
+            {props.children}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default EditButton;

--- a/admin/next-project/seeft-admin/src/components/common/EditButton/index.ts
+++ b/admin/next-project/seeft-admin/src/components/common/EditButton/index.ts
@@ -1,0 +1,1 @@
+export { default } from './EditButton';

--- a/admin/next-project/seeft-admin/src/components/common/index.ts
+++ b/admin/next-project/seeft-admin/src/components/common/index.ts
@@ -1,3 +1,7 @@
 export { default as Card } from './Card'
 export { default as Header } from './Header';
-export { default as SideNav } from './SideNav'
+export { default as SideNav } from './SideNav';
+export { default as Select } from './Select';
+export { default as Input } from './Input';
+export { default as EditButton } from './EditButton';
+export { default as DeleteButton } from './DeleteButton';

--- a/admin/next-project/seeft-admin/src/components/layout/InformationPageLayout/InformationPageLayout.tsx
+++ b/admin/next-project/seeft-admin/src/components/layout/InformationPageLayout/InformationPageLayout.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import MainLayout from '@components/layout/MainLayout';
+import Button from '@components/common/Button';
+
+interface LayoutProps {
+  title?: string;
+  submitText?: string;
+  onClick?: () => void;
+  children?: React.ReactNode;
+}
+
+export default function InformationPageLayout(props: LayoutProps) {
+  return (
+    <MainLayout>
+      <div className='mx-auto relative md:w-1/2 h-full bg-white-0 p-8'>
+        <div className='mx-auto w-fit text-xl text-emphasis mb-8'>
+          {props.title}
+        </div>
+        <div className='flex flex-col gap-3'>
+          <div className='my-4 flex flex-col items-center justify-items-end gap-5 text-base text-emphasis'>
+            {props.children}
+          </div>
+        </div>
+        <div className='mx-auto w-fit text-emphasis mb-8'>
+          <Button className='bg-surface-2 hover:bg-surface-1'
+            onClick={props.onClick}>
+            {props.submitText}
+          </Button>
+        </div>
+      </div>
+    </MainLayout>
+  );
+}

--- a/admin/next-project/seeft-admin/src/components/layout/InformationPageLayout/index.ts
+++ b/admin/next-project/seeft-admin/src/components/layout/InformationPageLayout/index.ts
@@ -1,0 +1,1 @@
+export { default } from './InformationPageLayout';

--- a/admin/next-project/seeft-admin/src/components/layout/ListPageLayout/ListPageLayout.tsx
+++ b/admin/next-project/seeft-admin/src/components/layout/ListPageLayout/ListPageLayout.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import MainLayout from '@components/layout/MainLayout';
+
+interface LayoutProps {
+  title?: string;
+  children?: React.ReactNode;
+}
+
+export default function ListPageLayout(props: LayoutProps) {
+  return (
+    <MainLayout>
+      <div className='w-full h-full bg-white-0 flex-col p-8'>
+        <div className='items-center text-xl text-emphasis'>
+          {props.title}
+        </div>
+        <div>
+          {props.children}
+        </div>
+      </div>
+    </MainLayout>
+  );
+}

--- a/admin/next-project/seeft-admin/src/components/layout/ListPageLayout/index.ts
+++ b/admin/next-project/seeft-admin/src/components/layout/ListPageLayout/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ListPageLayout';

--- a/admin/next-project/seeft-admin/src/pages/places/[id]/detail-place.tsx
+++ b/admin/next-project/seeft-admin/src/pages/places/[id]/detail-place.tsx
@@ -1,15 +1,11 @@
-import clsx from 'clsx';
-import Head from 'next/head';
-
-import { get } from '@api/api_methods';
-import { Place } from "@type/common";
-import MainLayout from '@components/layout/MainLayout';
-import Button from '@components/common/Button';
-import Input from '@components/common/Input';
 import React, { useState } from 'react';
-
-import { post } from '@api/place';
 import { useRouter } from 'next/router';
+
+import { Place } from "@type/common";
+import Input from '@components/common/Input';
+import { get } from '@api/api_methods';
+import { post } from '@api/place';
+import InformationPageLayout from '@components/layout/InformationPageLayout';
 
 interface Props {
   place: Place;
@@ -43,45 +39,27 @@ export default function Places(props: Props) {
       setFormData({ ...formData, [input]: e.target.value });
     }
 
-  const addPlaceInformation = async (data: Place) => {
+  const updatePlaceInformation = async (data: Place) => {
     const addPlaceInformationUrl = process.env.CSR_API_URI + '/places';
     await post(addPlaceInformationUrl, data);
     router.push('/places');
   };
 
   return (
-    <MainLayout>
-      <div className='mx-auto relative md:w-1/2 h-full bg-white-0 p-8'>
-        <div className=''>
-          <div className='mx-auto w-fit text-xl text-emphasis mb-8'>
-            集合場所詳細
-          </div>
-          <div className='flex flex-col gap-3'>
-            <div className='my-4 flex flex-col items-center justify-items-end gap-5 text-base text-emphasis'>
-              <div className='flex w-full items-center'>
-                <div className='flex w-1/4'>集合場所</div>
-                <div className='col-span-4 w-full'>
-                  <Input className='w-full' value={formData.place} onChange={handler('place')} />
-                </div>
-              </div>
-              <div className='flex w-full items-center'>
-                <div className='flex w-1/4'>備考</div>
-                <div className='col-span-4 w-full'>
-                  <Input className='w-full' value={formData.remark} onChange={handler('remark')} />
-                </div>
-              </div>
-            </div>
-          </div>
-          <div className='mx-auto w-fit text-emphasis mb-8'>
-            <Button className='bg-surface-2 hover:bg-surface-1'
-              onClick={() => {
-                addPlaceInformation(formData);
-              }}>
-              登録
-            </Button>
-          </div>
+    <InformationPageLayout title='集合場所詳細' submitText='編集' onClick={() => { updatePlaceInformation(formData); }}>
+      <div className='flex w-full items-center'>
+        <div className='flex w-1/4'>集合場所</div>
+        <div className='col-span-4 w-full'>
+          <Input className='w-full' value={formData.place} onChange={handler('place')} />
         </div>
-      </div >
-    </MainLayout >
+      </div>
+      <div className='flex w-full items-center'>
+        <div className='flex w-1/4'>備考</div>
+        <div className='col-span-4 w-full'>
+          <Input className='w-full' value={formData.remark} onChange={handler('remark')} />
+        </div>
+      </div>
+    </InformationPageLayout>
+
   );
 }

--- a/admin/next-project/seeft-admin/src/pages/places/[id]/detail-place.tsx
+++ b/admin/next-project/seeft-admin/src/pages/places/[id]/detail-place.tsx
@@ -1,0 +1,87 @@
+import clsx from 'clsx';
+import Head from 'next/head';
+
+import { get } from '@api/api_methods';
+import { Place } from "@type/common";
+import MainLayout from '@components/layout/MainLayout';
+import Button from '@components/common/Button';
+import Input from '@components/common/Input';
+import React, { useState } from 'react';
+
+import { post } from '@api/place';
+import { useRouter } from 'next/router';
+
+interface Props {
+  place: Place;
+}
+
+export const getServerSideProps = async (
+  { params }: { params: { id: string } }) => {
+  const placeID = params.id;
+  const getPlaceURL = process.env.SSR_API_URI + '/places/' + placeID;
+  const placeRes = await get(getPlaceURL);
+
+  return {
+    props: {
+      place: placeRes,
+    },
+  };
+};
+
+export default function Places(props: Props) {
+  const { place } = props;
+  const router = useRouter();
+
+  const [formData, setFormData] = useState<Place>({
+    id: place.id,
+    place: place.place,
+    remark: place.remark,
+  });
+
+  const handler = (input: string) =>
+    (e: React.ChangeEvent<HTMLSelectElement> | React.ChangeEvent<HTMLInputElement>) => {
+      setFormData({ ...formData, [input]: e.target.value });
+    }
+
+  const addPlaceInformation = async (data: Place) => {
+    const addPlaceInformationUrl = process.env.CSR_API_URI + '/places';
+    await post(addPlaceInformationUrl, data);
+    router.push('/places');
+  };
+
+  return (
+    <MainLayout>
+      <div className='mx-auto relative md:w-1/2 h-full bg-white-0 p-8'>
+        <div className=''>
+          <div className='mx-auto w-fit text-xl text-emphasis mb-8'>
+            集合場所詳細
+          </div>
+          <div className='flex flex-col gap-3'>
+            <div className='my-4 flex flex-col items-center justify-items-end gap-5 text-base text-emphasis'>
+              <div className='flex w-full items-center'>
+                <div className='flex w-1/4'>集合場所</div>
+                <div className='col-span-4 w-full'>
+                  <Input className='w-full' value={formData.place} onChange={handler('place')} />
+                </div>
+              </div>
+              <div className='flex w-full items-center'>
+                <div className='flex w-1/4'>備考</div>
+                <div className='col-span-4 w-full'>
+                  <Input className='w-full' value={formData.remark} onChange={handler('remark')} />
+                </div>
+              </div>
+            </div>
+          </div>
+          <div className='mx-auto w-fit text-emphasis mb-8'>
+            <Button className='bg-surface-2 hover:bg-surface-1'
+              onClick={() => {
+                addPlaceInformation(formData);
+              }}>
+              登録
+            </Button>
+          </div>
+        </div>
+      </div >
+    </MainLayout >
+  );
+}

--- a/admin/next-project/seeft-admin/src/pages/places/[id]/detail-place.tsx
+++ b/admin/next-project/seeft-admin/src/pages/places/[id]/detail-place.tsx
@@ -4,7 +4,7 @@ import { useRouter } from 'next/router';
 import { Place } from "@type/common";
 import Input from '@components/common/Input';
 import { get } from '@api/api_methods';
-import { post } from '@api/place';
+import { put } from '@api/place';
 import InformationPageLayout from '@components/layout/InformationPageLayout';
 
 interface Props {
@@ -40,8 +40,8 @@ export default function Places(props: Props) {
     }
 
   const updatePlaceInformation = async (data: Place) => {
-    const putPlaceInformationUrl = process.env.CSR_API_URI + '/places';
-    await post(putPlaceInformationUrl, data);
+    const putPlaceInformationUrl = process.env.CSR_API_URI + '/places/' + data.id;
+    await put(putPlaceInformationUrl, data);
     router.push('/places');
   };
 

--- a/admin/next-project/seeft-admin/src/pages/places/[id]/detail-place.tsx
+++ b/admin/next-project/seeft-admin/src/pages/places/[id]/detail-place.tsx
@@ -40,8 +40,8 @@ export default function Places(props: Props) {
     }
 
   const updatePlaceInformation = async (data: Place) => {
-    const addPlaceInformationUrl = process.env.CSR_API_URI + '/places';
-    await post(addPlaceInformationUrl, data);
+    const putPlaceInformationUrl = process.env.CSR_API_URI + '/places';
+    await post(putPlaceInformationUrl, data);
     router.push('/places');
   };
 

--- a/admin/next-project/seeft-admin/src/pages/places/add-place/index.tsx
+++ b/admin/next-project/seeft-admin/src/pages/places/add-place/index.tsx
@@ -1,0 +1,68 @@
+import clsx from 'clsx';
+import Head from 'next/head';
+
+import { Place } from "@type/common";
+import MainLayout from '@components/layout/MainLayout';
+import Button from '@components/common/Button';
+import Input from '@components/common/Input';
+import React, { useState } from 'react';
+
+import { post } from '@api/place';
+import { useRouter } from 'next/router';
+
+export default function Places() {
+  const router = useRouter();
+
+  const [formData, setFormData] = useState<Place>({
+    id: 0,
+    place: '',
+    remark: '',
+  });
+
+  const handler = (input: string) =>
+    (e: React.ChangeEvent<HTMLSelectElement> | React.ChangeEvent<HTMLInputElement>) => {
+      setFormData({ ...formData, [input]: e.target.value });
+    }
+
+  const addPlaceInformation = async (data: Place) => {
+    const addPlaceInformationUrl = process.env.CSR_API_URI + '/places';
+    await post(addPlaceInformationUrl, data);
+    router.push('/places');
+  };
+
+  return (
+    <MainLayout>
+      <div className='mx-auto relative md:w-1/2 h-full bg-white-0 p-8'>
+        <div className=''>
+          <div className='mx-auto w-fit text-xl text-emphasis mb-8'>
+            集合場所登録
+          </div>
+          <div className='flex flex-col gap-3'>
+            <div className='my-4 flex flex-col items-center justify-items-end gap-5 text-base text-emphasis'>
+              <div className='flex w-full items-center'>
+                <div className='flex w-1/4'>集合場所</div>
+                <div className='col-span-4 w-full'>
+                  <Input className='w-full' value={formData.place} onChange={handler('place')} />
+                </div>
+              </div>
+              <div className='flex w-full items-center'>
+                <div className='flex w-1/4'>備考</div>
+                <div className='col-span-4 w-full'>
+                  <Input className='w-full' value={formData.remark} onChange={handler('remark')} />
+                </div>
+              </div>
+            </div>
+          </div>
+          <div className='mx-auto w-fit text-emphasis mb-8'>
+            <Button className='bg-surface-2 hover:bg-surface-1'
+              onClick={() => {
+                addPlaceInformation(formData);
+              }}>
+              登録
+            </Button>
+          </div>
+        </div>
+      </div >
+    </MainLayout >
+  );
+}

--- a/admin/next-project/seeft-admin/src/pages/places/add-place/index.tsx
+++ b/admin/next-project/seeft-admin/src/pages/places/add-place/index.tsx
@@ -1,14 +1,10 @@
-import clsx from 'clsx';
-import Head from 'next/head';
+import React, { useState } from 'react';
+import { useRouter } from 'next/router';
 
 import { Place } from "@type/common";
-import MainLayout from '@components/layout/MainLayout';
-import Button from '@components/common/Button';
 import Input from '@components/common/Input';
-import React, { useState } from 'react';
-
 import { post } from '@api/place';
-import { useRouter } from 'next/router';
+import InformationPageLayout from '@components/layout/InformationPageLayout';
 
 export default function Places() {
   const router = useRouter();
@@ -31,38 +27,19 @@ export default function Places() {
   };
 
   return (
-    <MainLayout>
-      <div className='mx-auto relative md:w-1/2 h-full bg-white-0 p-8'>
-        <div className=''>
-          <div className='mx-auto w-fit text-xl text-emphasis mb-8'>
-            集合場所登録
-          </div>
-          <div className='flex flex-col gap-3'>
-            <div className='my-4 flex flex-col items-center justify-items-end gap-5 text-base text-emphasis'>
-              <div className='flex w-full items-center'>
-                <div className='flex w-1/4'>集合場所</div>
-                <div className='col-span-4 w-full'>
-                  <Input className='w-full' value={formData.place} onChange={handler('place')} />
-                </div>
-              </div>
-              <div className='flex w-full items-center'>
-                <div className='flex w-1/4'>備考</div>
-                <div className='col-span-4 w-full'>
-                  <Input className='w-full' value={formData.remark} onChange={handler('remark')} />
-                </div>
-              </div>
-            </div>
-          </div>
-          <div className='mx-auto w-fit text-emphasis mb-8'>
-            <Button className='bg-surface-2 hover:bg-surface-1'
-              onClick={() => {
-                addPlaceInformation(formData);
-              }}>
-              登録
-            </Button>
-          </div>
+    <InformationPageLayout title='集合場所登録' submitText='登録' onClick={() => { addPlaceInformation(formData); }}>
+      <div className='flex w-full items-center'>
+        <div className='flex w-1/4'>集合場所</div>
+        <div className='col-span-4 w-full'>
+          <Input className='w-full' value={formData.place} onChange={handler('place')} />
         </div>
-      </div >
-    </MainLayout >
+      </div>
+      <div className='flex w-full items-center'>
+        <div className='flex w-1/4'>備考</div>
+        <div className='col-span-4 w-full'>
+          <Input className='w-full' value={formData.remark} onChange={handler('remark')} />
+        </div>
+      </div>
+    </InformationPageLayout>
   );
 }

--- a/admin/next-project/seeft-admin/src/pages/places/index.tsx
+++ b/admin/next-project/seeft-admin/src/pages/places/index.tsx
@@ -91,12 +91,12 @@ export default function Uesrs(props: Props) {
                   </td>
                   <td
                     className={clsx(
-                      'px-1 py-2 rounded-full hover:bg-accent-1',
+                      'px-1 py-2',
                       index === 0 ? 'pb-3 pt-4' : 'py-3',
                       index === places.length - 1 ? 'pb-4 pt-3' : 'border-b-accent-1 py-3',
                     )}
                   >
-                    <div className='flex justify-items-center gap-4'
+                    <div className='flex justify-items-center gap-4 rounded-full hover:bg-accent-1'
                       onClick={() => { PlaceDetailPageRouter(place) }}>
                       <MdEdit />
                       <p className='text-center text-sm text-emphasis'>
@@ -106,12 +106,12 @@ export default function Uesrs(props: Props) {
                   </td>
                   <td
                     className={clsx(
-                      'px-1 py-2 rounded-full hover:bg-accent-1',
+                      'px-1 py-2 ',
                       index === 0 ? 'pb-3 pt-4' : 'py-3',
                       index === places.length - 1 ? 'pb-4 pt-3' : 'border-b-accent-1 py-3',
                     )}
                   >
-                    <div className='flex justify-items-center gap-4'
+                    <div className='flex justify-items-center gap-4 rounded-full hover:bg-accent-1'
                       onClick={() => { destroyPlaceInformation(place); }}>
                       <MdDeleteForever />
                       <p className='text-center text-sm text-emphasis'>

--- a/admin/next-project/seeft-admin/src/pages/places/index.tsx
+++ b/admin/next-project/seeft-admin/src/pages/places/index.tsx
@@ -7,6 +7,8 @@ import MainLayout from '@components/layout/MainLayout';
 import { MdEdit, MdDeleteForever } from "react-icons/md";
 import Button from '@components/common/Button';
 import { destroy } from '@api/place';
+import ListPageLayout from '@components/layout/ListPageLayout';
+import { DeleteButton, EditButton } from '@components/common';
 
 interface Props {
   places: Place[];
@@ -31,7 +33,7 @@ export default function Uesrs(props: Props) {
     router.push('places/add-place');
   }
 
-  const PlaceDetailPageRouter = (place: Place) => {
+  const placeDetailPageRouter = (place: Place) => {
     router.push('places/' + place.id + '/detail-place');
   }
 
@@ -42,89 +44,76 @@ export default function Uesrs(props: Props) {
   };
 
   return (
-    <MainLayout>
-      <div className='w-full h-full bg-white-0 flex-col p-8'>
-        <div className='items-center text-xl text-emphasis'>
-          集合場所一覧
-        </div>
-        <div className='items-center'>
-          <div className='text-right pr-4'>
-            <Button className='bg-surface-2 border-accent-2 text-right text-emphasis pr-4 hover:bg-surface-1' onClick={addPlacePageRouter}>
-              集合場所追加
-            </Button>
-          </div>
-        </div>
-        <div className='p-5'>
-          <table className='mb-5 w-full table-auto border-collapse'>
-            <thead>
-              <tr>
-                <th className='w-1/4 border border-x-white-0 border-b-accent-1 border-t-white-0 py-3'>
-                  <p className='text-center text-sm text-emphasis'>場所</p>
-                </th>
-                <th className='w-1/4 border border-x-white-0 border-b-accent-1 border-t-white-0 py-3'>
-                  <p className='text-center text-sm text-emphasis'>備考</p>
-                </th>
-                <th className='w-1/12 border border-x-white-0 border-b-accent-1 border-t-white-0 py-3' />
-                <th className='w-1/12 border border-x-white-0 border-b-accent-1 border-t-white-0 py-3' />
-              </tr>
-            </thead>
-            <tbody className='border border-x-white-0 border-b-accent-1 border-t-white-0'>
-              {places ? places.map((place: Place, index) => (
-                <tr key={place.id}>
-                  <td
-                    className={clsx(
-                      'px-1 py-2',
-                      index === 0 ? 'pb-3 pt-4' : 'py-3',
-                      index === places.length - 1 ? 'pb-4 pt-3' : 'border-b-accent-1 py-3',
-                    )}
-                  >
-                    <p className='text-center text-sm text-emphasis'>{place.place}</p>
-                  </td>
-                  <td
-                    className={clsx(
-                      'px-1 py-2',
-                      index === 0 ? 'pb-3 pt-4' : 'py-3',
-                      index === places.length - 1 ? 'pb-4 pt-3' : 'border-b-accent-1 py-3',
-                    )}
-                  >
-                    <p className='text-center text-sm text-emphasis'>{place.remark}</p>
-                  </td>
-                  <td
-                    className={clsx(
-                      'px-1 py-2',
-                      index === 0 ? 'pb-3 pt-4' : 'py-3',
-                      index === places.length - 1 ? 'pb-4 pt-3' : 'border-b-accent-1 py-3',
-                    )}
-                  >
-                    <div className='flex justify-items-center gap-4 rounded-full hover:bg-accent-1'
-                      onClick={() => { PlaceDetailPageRouter(place) }}>
-                      <MdEdit />
-                      <p className='text-center text-sm text-emphasis'>
-                        編集
-                      </p>
-                    </div>
-                  </td>
-                  <td
-                    className={clsx(
-                      'px-1 py-2 ',
-                      index === 0 ? 'pb-3 pt-4' : 'py-3',
-                      index === places.length - 1 ? 'pb-4 pt-3' : 'border-b-accent-1 py-3',
-                    )}
-                  >
-                    <div className='flex justify-items-center gap-4 rounded-full hover:bg-accent-1'
-                      onClick={() => { destroyPlaceInformation(place); }}>
-                      <MdDeleteForever />
-                      <p className='text-center text-sm text-emphasis'>
-                        削除
-                      </p>
-                    </div>
-                  </td>
-                </tr>
-              )) : null}
-            </tbody>
-          </table>
+    <ListPageLayout title='集合場所一覧'>
+      <div className='items-center'>
+        <div className='text-right pr-4'>
+          <Button className='bg-surface-2 border-accent-2 text-right text-emphasis pr-4 hover:bg-surface-1' onClick={addPlacePageRouter}>
+            集合場所追加
+          </Button>
         </div>
       </div>
-    </MainLayout >
+      <div className='p-5'>
+        <table className='mb-5 w-full table-auto border-collapse'>
+          <thead>
+            <tr>
+              <th className='w-1/4 border border-x-white-0 border-b-accent-1 border-t-white-0 py-3'>
+                <p className='text-center text-sm text-emphasis'>場所</p>
+              </th>
+              <th className='w-1/4 border border-x-white-0 border-b-accent-1 border-t-white-0 py-3'>
+                <p className='text-center text-sm text-emphasis'>備考</p>
+              </th>
+              <th className='w-1/12 border border-x-white-0 border-b-accent-1 border-t-white-0 py-3' />
+              <th className='w-1/12 border border-x-white-0 border-b-accent-1 border-t-white-0 py-3' />
+            </tr>
+          </thead>
+          <tbody className='border border-x-white-0 border-b-accent-1 border-t-white-0'>
+            {places ? places.map((place: Place, index) => (
+              <tr key={place.id}>
+                <td
+                  className={clsx(
+                    'px-1 py-2',
+                    index === 0 ? 'pb-3 pt-4' : 'py-2',
+                    index === places.length - 1 ? 'pb-4 pt-2' : 'border-b-accent-1 py-3',
+                  )}
+                >
+                  <p className='text-center text-sm text-emphasis'>{place.place}</p>
+                </td>
+                <td
+                  className={clsx(
+                    'px-1 py-2',
+                    index === 0 ? 'pb-3 pt-4' : 'py-2',
+                    index === places.length - 1 ? 'pb-4 pt-2' : 'border-b-accent-1 py-3',
+                  )}
+                >
+                  <p className='text-center text-sm text-emphasis'>{place.remark}</p>
+                </td>
+                <td
+                  className={clsx(
+                    'px-1 py-2',
+                    index === 0 ? 'pb-3 pt-4' : 'py-2',
+                    index === places.length - 1 ? 'pb-4 pt-2' : 'border-b-accent-1 py-3',
+                  )}
+                >
+                  <EditButton onClick={() => { placeDetailPageRouter(place) }}>
+                    編集
+                  </EditButton>
+                </td>
+                <td
+                  className={clsx(
+                    'px-1 py-2 ',
+                    index === 0 ? 'pb-3 pt-4' : 'py-2',
+                    index === places.length - 1 ? 'pb-4 pt-2' : 'border-b-accent-1 py-3',
+                  )}
+                >
+                  <DeleteButton onClick={() => { destroyPlaceInformation(place) }} >
+                    削除
+                  </DeleteButton>
+                </td>
+              </tr>
+            )) : null}
+          </tbody>
+        </table>
+      </div>
+    </ListPageLayout>
   );
 }

--- a/admin/next-project/seeft-admin/src/pages/places/index.tsx
+++ b/admin/next-project/seeft-admin/src/pages/places/index.tsx
@@ -1,0 +1,130 @@
+import clsx from 'clsx';
+import { useRouter } from 'next/router';
+
+import { get } from '@api/api_methods';
+import { Place } from "@type/common";
+import MainLayout from '@components/layout/MainLayout';
+import { MdEdit, MdDeleteForever } from "react-icons/md";
+import Button from '@components/common/Button';
+import { destroy } from '@api/place';
+
+interface Props {
+  places: Place[];
+}
+
+export const getServerSideProps = async () => {
+  const getPlaceURL = process.env.SSR_API_URI + '/places';
+  const placeRes = await get(getPlaceURL);
+
+  return {
+    props: {
+      places: placeRes,
+    },
+  };
+};
+
+export default function Uesrs(props: Props) {
+  const { places } = props;
+  const router = useRouter();
+
+  const addPlacePageRouter = () => {
+    router.push('places/add-place');
+  }
+
+  const PlaceDetailPageRouter = (place: Place) => {
+    router.push('places/' + place.id + '/detail-place');
+  }
+
+  const destroyPlaceInformation = async (data: Place) => {
+    const destroyPlaceInformationUrl = process.env.CSR_API_URI + '/places';
+    await destroy(destroyPlaceInformationUrl, data);
+    router.reload();
+  };
+
+  return (
+    <MainLayout>
+      <div className='w-full h-full bg-white-0 flex-col p-8'>
+        <div className='items-center text-xl text-emphasis'>
+          集合場所一覧
+        </div>
+        <div className='items-center'>
+          <div className='text-right pr-4'>
+            <Button className='bg-surface-2 border-accent-2 text-right text-emphasis pr-4 hover:bg-surface-1' onClick={addPlacePageRouter}>
+              集合場所追加
+            </Button>
+          </div>
+        </div>
+        <div className='p-5'>
+          <table className='mb-5 w-full table-auto border-collapse'>
+            <thead>
+              <tr>
+                <th className='w-1/4 border border-x-white-0 border-b-accent-1 border-t-white-0 py-3'>
+                  <p className='text-center text-sm text-emphasis'>場所</p>
+                </th>
+                <th className='w-1/4 border border-x-white-0 border-b-accent-1 border-t-white-0 py-3'>
+                  <p className='text-center text-sm text-emphasis'>備考</p>
+                </th>
+                <th className='w-1/12 border border-x-white-0 border-b-accent-1 border-t-white-0 py-3' />
+                <th className='w-1/12 border border-x-white-0 border-b-accent-1 border-t-white-0 py-3' />
+              </tr>
+            </thead>
+            <tbody className='border border-x-white-0 border-b-accent-1 border-t-white-0'>
+              {places ? places.map((place: Place, index) => (
+                <tr key={place.id}>
+                  <td
+                    className={clsx(
+                      'px-1 py-2',
+                      index === 0 ? 'pb-3 pt-4' : 'py-3',
+                      index === places.length - 1 ? 'pb-4 pt-3' : 'border-b-accent-1 py-3',
+                    )}
+                  >
+                    <p className='text-center text-sm text-emphasis'>{place.place}</p>
+                  </td>
+                  <td
+                    className={clsx(
+                      'px-1 py-2',
+                      index === 0 ? 'pb-3 pt-4' : 'py-3',
+                      index === places.length - 1 ? 'pb-4 pt-3' : 'border-b-accent-1 py-3',
+                    )}
+                  >
+                    <p className='text-center text-sm text-emphasis'>{place.remark}</p>
+                  </td>
+                  <td
+                    className={clsx(
+                      'px-1 py-2 rounded-full hover:bg-accent-1',
+                      index === 0 ? 'pb-3 pt-4' : 'py-3',
+                      index === places.length - 1 ? 'pb-4 pt-3' : 'border-b-accent-1 py-3',
+                    )}
+                  >
+                    <div className='flex justify-items-center gap-4'
+                      onClick={() => { PlaceDetailPageRouter(place) }}>
+                      <MdEdit />
+                      <p className='text-center text-sm text-emphasis'>
+                        編集
+                      </p>
+                    </div>
+                  </td>
+                  <td
+                    className={clsx(
+                      'px-1 py-2 rounded-full hover:bg-accent-1',
+                      index === 0 ? 'pb-3 pt-4' : 'py-3',
+                      index === places.length - 1 ? 'pb-4 pt-3' : 'border-b-accent-1 py-3',
+                    )}
+                  >
+                    <div className='flex justify-items-center gap-4'
+                      onClick={() => { destroyPlaceInformation(place); }}>
+                      <MdDeleteForever />
+                      <p className='text-center text-sm text-emphasis'>
+                        削除
+                      </p>
+                    </div>
+                  </td>
+                </tr>
+              )) : null}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </MainLayout >
+  );
+}

--- a/admin/next-project/seeft-admin/src/pages/users/[id]/detail-user.tsx
+++ b/admin/next-project/seeft-admin/src/pages/users/[id]/detail-user.tsx
@@ -146,7 +146,7 @@ export default function Users(props: Props) {
               onClick={() => {
                 putUserInformation(formData);
               }}>
-              登録
+              編集
             </Button>
           </div>
         </div>

--- a/admin/next-project/seeft-admin/src/pages/users/[id]/detail-user.tsx
+++ b/admin/next-project/seeft-admin/src/pages/users/[id]/detail-user.tsx
@@ -1,17 +1,11 @@
-import clsx from 'clsx';
-import Head from 'next/head';
+import React, { useState } from 'react';
+import { useRouter } from 'next/router';
 
 import { get } from '@api/api_methods';
 import { User, Grade, Department, Bureau } from "@type/common";
-import MainLayout from '@components/layout/MainLayout';
-import { MdEdit, MdDeleteForever } from "react-icons/md";
-import Button from '@components/common/Button';
-import Input from '@components/common/Input';
-import Select from '@components/common/Select';
-import React, { useState } from 'react';
-
+import { Input, Select } from '@components/common';
 import { put } from '@api/user';
-import { useRouter } from 'next/router';
+import InformationPageLayout from '@components/layout/InformationPageLayout';
 
 interface Props {
   grades: Grade[];
@@ -64,93 +58,74 @@ export default function Users(props: Props) {
       setFormData({ ...formData, [input]: e.target.value });
     }
 
-  const putUserInformation = async (data: User) => {
+  const updateUserInformation = async (data: User) => {
     const putUserInformationUrl = process.env.CSR_API_URI + '/users/' + data.id;
     await put(putUserInformationUrl, data);
     router.push('/users');
   };
 
   return (
-    <MainLayout>
-      <div className='mx-auto relative md:w-1/2 h-full bg-white-0 p-8'>
-        <div className=''>
-          <div className='mx-auto w-fit text-xl text-emphasis mb-8'>
-            ユーザー詳細
-          </div>
-          <div className='flex flex-col gap-3'>
-            <div className='my-4 flex flex-col items-center justify-items-end gap-5 text-base text-emphasis'>
-              <div className='flex w-full items-center'>
-                <div className='flex w-1/4'>学籍番号</div>
-                <div className='col-span-4 w-full'>
-                  <Input className='w-full' value={formData.studentNumber} onChange={handler('studentNumber')} />
-                </div>
-              </div>
-              <div className='flex w-full items-center'>
-                <div className='flex w-1/4'>名前</div>
-                <div className='col-span-4 w-full'>
-                  <Input className='w-full' value={formData.name} onChange={handler('name')} />
-                </div>
-              </div>
-              <div className='flex w-full items-center'>
-                <div className='flex w-1/4'>所属局</div>
-                <div className='col-span-4 w-full'>
-                  <Select className='w-full' value={formData.bureauID} onChange={handler('bureauID')}>
-                    {bureaus.map((data) => (
-                      <option key={data.id} value={data.id}>
-                        {data.bureau}
-                      </option>
-                    ))}
-                  </Select>
-                </div>
-              </div>
-              <div className='flex w-full items-center'>
-                <div className='flex w-1/4'>課程</div>
-                <div className='col-span-4 w-full'>
-                  <Select className='w-full' value={formData.departmentID} onChange={handler('departmentID')}>
-                    {departments.length > 1 ? departments.map((data) => (
-                      <option key={data.id} value={data.id}>
-                        {data.department}
-                      </option>
-                    )) : null}
-                  </Select>
-                </div>
-              </div>
-              <div className='flex w-full items-center'>
-                <div className='flex w-1/4'>学年</div>
-                <div className='col-span-4 w-full'>
-                  <Select className='w-full' value={formData.gradeID} onChange={handler('gradeID')}>
-                    {grades.map((data) => (
-                      <option key={data.id} value={data.id}>
-                        {data.grade}
-                      </option>
-                    ))}
-                  </Select>
-                </div>
-              </div>
-              <div className='flex w-full items-center'>
-                <div className='flex w-1/4'>電話番号</div>
-                <div className='col-span-4 w-full'>
-                  <Input className='w-full' value={formData.tel} onChange={handler('tel')} />
-                </div>
-              </div>
-              <div className='flex w-full items-center'>
-                <div className='flex w-1/4'>メールアドレス</div>
-                <div className='col-span-4 w-full'>
-                  <Input className='w-full' value={formData.mail} onChange={handler('mail')} />
-                </div>
-              </div>
-            </div>
-          </div>
-          <div className='mx-auto w-fit text-emphasis mb-8'>
-            <Button className='bg-surface-2 hover:bg-surface-1'
-              onClick={() => {
-                putUserInformation(formData);
-              }}>
-              編集
-            </Button>
-          </div>
+    <InformationPageLayout title='ユーザー詳細' submitText='編集' onClick={() => { updateUserInformation(formData); }}>
+      <div className='flex w-full items-center'>
+        <div className='flex w-1/4'>学籍番号</div>
+        <div className='col-span-4 w-full'>
+          <Input className='w-full' value={formData.studentNumber} onChange={handler('studentNumber')} />
         </div>
-      </div >
-    </MainLayout >
+      </div>
+      <div className='flex w-full items-center'>
+        <div className='flex w-1/4'>名前</div>
+        <div className='col-span-4 w-full'>
+          <Input className='w-full' value={formData.name} onChange={handler('name')} />
+        </div>
+      </div>
+      <div className='flex w-full items-center'>
+        <div className='flex w-1/4'>所属局</div>
+        <div className='col-span-4 w-full'>
+          <Select className='w-full' value={formData.bureauID} onChange={handler('bureauID')}>
+            {bureaus.map((data) => (
+              <option key={data.id} value={data.id}>
+                {data.bureau}
+              </option>
+            ))}
+          </Select>
+        </div>
+      </div>
+      <div className='flex w-full items-center'>
+        <div className='flex w-1/4'>課程</div>
+        <div className='col-span-4 w-full'>
+          <Select className='w-full' value={formData.departmentID} onChange={handler('departmentID')}>
+            {departments.length > 1 ? departments.map((data) => (
+              <option key={data.id} value={data.id}>
+                {data.department}
+              </option>
+            )) : null}
+          </Select>
+        </div>
+      </div>
+      <div className='flex w-full items-center'>
+        <div className='flex w-1/4'>学年</div>
+        <div className='col-span-4 w-full'>
+          <Select className='w-full' value={formData.gradeID} onChange={handler('gradeID')}>
+            {grades.map((data) => (
+              <option key={data.id} value={data.id}>
+                {data.grade}
+              </option>
+            ))}
+          </Select>
+        </div>
+      </div>
+      <div className='flex w-full items-center'>
+        <div className='flex w-1/4'>電話番号</div>
+        <div className='col-span-4 w-full'>
+          <Input className='w-full' value={formData.tel} onChange={handler('tel')} />
+        </div>
+      </div>
+      <div className='flex w-full items-center'>
+        <div className='flex w-1/4'>メールアドレス</div>
+        <div className='col-span-4 w-full'>
+          <Input className='w-full' value={formData.mail} onChange={handler('mail')} />
+        </div>
+      </div>
+    </InformationPageLayout>
   );
 }

--- a/admin/next-project/seeft-admin/src/pages/users/[id]/detail-user.tsx
+++ b/admin/next-project/seeft-admin/src/pages/users/[id]/detail-user.tsx
@@ -42,7 +42,7 @@ export const getServerSideProps = async (
   };
 };
 
-export default function Uesrs(props: Props) {
+export default function Users(props: Props) {
   const { grades, departments, bureaus, user } = props;
   const router = useRouter();
 
@@ -75,7 +75,7 @@ export default function Uesrs(props: Props) {
       <div className='mx-auto relative md:w-1/2 h-full bg-white-0 p-8'>
         <div className=''>
           <div className='mx-auto w-fit text-xl text-emphasis mb-8'>
-            ユーザー登録
+            ユーザー詳細
           </div>
           <div className='flex flex-col gap-3'>
             <div className='my-4 flex flex-col items-center justify-items-end gap-5 text-base text-emphasis'>

--- a/admin/next-project/seeft-admin/src/pages/users/add-user/index.tsx
+++ b/admin/next-project/seeft-admin/src/pages/users/add-user/index.tsx
@@ -36,7 +36,7 @@ export const getServerSideProps = async () => {
   };
 };
 
-export default function Uesrs(props: Props) {
+export default function Users(props: Props) {
   const { grades, departments, bureaus } = props;
   const router = useRouter();
 

--- a/admin/next-project/seeft-admin/src/pages/users/add-user/index.tsx
+++ b/admin/next-project/seeft-admin/src/pages/users/add-user/index.tsx
@@ -1,17 +1,11 @@
-import clsx from 'clsx';
-import Head from 'next/head';
+import React, { useState } from 'react';
+import { useRouter } from 'next/router';
 
 import { get } from '@api/api_methods';
 import { User, Grade, Department, Bureau } from "@type/common";
-import MainLayout from '@components/layout/MainLayout';
-import { MdEdit, MdDeleteForever } from "react-icons/md";
-import Button from '@components/common/Button';
-import Input from '@components/common/Input';
-import Select from '@components/common/Select';
-import React, { useState } from 'react';
-
+import { Input, Select } from '@components/common';
 import { post } from '@api/user';
-import { useRouter } from 'next/router';
+import InformationPageLayout from '@components/layout/InformationPageLayout';
 
 interface Props {
   grades: Grade[];
@@ -65,94 +59,75 @@ export default function Users(props: Props) {
   };
 
   return (
-    <MainLayout>
-      <div className='mx-auto relative md:w-1/2 h-full bg-white-0 p-8'>
-        <div className=''>
-          <div className='mx-auto w-fit text-xl text-emphasis mb-8'>
-            ユーザー登録
-          </div>
-          <div className='flex flex-col gap-3'>
-            <div className='my-4 flex flex-col items-center justify-items-end gap-5 text-base text-emphasis'>
-              <div className='flex w-full items-center'>
-                <div className='flex w-1/4'>学籍番号</div>
-                <div className='col-span-4 w-full'>
-                  <Input className='w-full' value={formData.studentNumber} onChange={handler('studentNumber')} />
-                </div>
-              </div>
-              <div className='flex w-full items-center'>
-                <div className='flex w-1/4 whitespace-nowrap'>パスワード</div>
-                <input
-                  type='password'
-                  className='rounded-full border border-primary-1 px-4 py-2 col-span-2 w-full'
-                  onChange={handler('Password')}
-                />
-              </div>
-              <div className='flex w-full items-center'>
-                <div className='flex w-1/4'>名前</div>
-                <div className='col-span-4 w-full'>
-                  <Input className='w-full' value={formData.name} onChange={handler('name')} />
-                </div>
-              </div>
-              <div className='flex w-full items-center'>
-                <div className='flex w-1/4'>所属局</div>
-                <div className='col-span-4 w-full'>
-                  <Select className='w-full' value={formData.bureauID} onChange={handler('bureauID')}>
-                    {bureaus.map((data) => (
-                      <option key={data.id} value={data.id}>
-                        {data.bureau}
-                      </option>
-                    ))}
-                  </Select>
-                </div>
-              </div>
-              <div className='flex w-full items-center'>
-                <div className='flex w-1/4'>課程</div>
-                <div className='col-span-4 w-full'>
-                  <Select className='w-full' value={formData.departmentID} onChange={handler('departmentID')}>
-                    {departments.length > 1 ? departments.map((data) => (
-                      <option key={data.id} value={data.id}>
-                        {data.department}
-                      </option>
-                    )) : null}
-                  </Select>
-                </div>
-              </div>
-              <div className='flex w-full items-center'>
-                <div className='flex w-1/4'>学年</div>
-                <div className='col-span-4 w-full'>
-                  <Select className='w-full' value={formData.gradeID} onChange={handler('gradeID')}>
-                    {grades.map((data) => (
-                      <option key={data.id} value={data.id}>
-                        {data.grade}
-                      </option>
-                    ))}
-                  </Select>
-                </div>
-              </div>
-              <div className='flex w-full items-center'>
-                <div className='flex w-1/4'>電話番号</div>
-                <div className='col-span-4 w-full'>
-                  <Input className='w-full' value={formData.tel} onChange={handler('tel')} />
-                </div>
-              </div>
-              <div className='flex w-full items-center'>
-                <div className='flex w-1/4'>メールアドレス</div>
-                <div className='col-span-4 w-full'>
-                  <Input className='w-full' value={formData.mail} onChange={handler('mail')} />
-                </div>
-              </div>
-            </div>
-          </div>
-          <div className='mx-auto w-fit text-emphasis mb-8'>
-            <Button className='bg-surface-2 hover:bg-surface-1'
-              onClick={() => {
-                addUserInformation(formData);
-              }}>
-              登録
-            </Button>
-          </div>
+    <InformationPageLayout title='ユーザー登録' submitText='登録' onClick={() => { addUserInformation(formData); }}>
+      <div className='flex w-full items-center'>
+        <div className='flex w-1/4'>学籍番号</div>
+        <div className='col-span-4 w-full'>
+          <Input className='w-full' value={formData.studentNumber} onChange={handler('studentNumber')} />
         </div>
-      </div >
-    </MainLayout >
+      </div>
+      <div className='flex w-full items-center'>
+        <div className='flex w-1/4 whitespace-nowrap'>パスワード</div>
+        <input
+          type='password'
+          className='rounded-full border border-primary-1 px-4 py-2 col-span-2 w-full'
+          onChange={handler('Password')}
+        />
+      </div>
+      <div className='flex w-full items-center'>
+        <div className='flex w-1/4'>名前</div>
+        <div className='col-span-4 w-full'>
+          <Input className='w-full' value={formData.name} onChange={handler('name')} />
+        </div>
+      </div>
+      <div className='flex w-full items-center'>
+        <div className='flex w-1/4'>所属局</div>
+        <div className='col-span-4 w-full'>
+          <Select className='w-full' value={formData.bureauID} onChange={handler('bureauID')}>
+            {bureaus.map((data) => (
+              <option key={data.id} value={data.id}>
+                {data.bureau}
+              </option>
+            ))}
+          </Select>
+        </div>
+      </div>
+      <div className='flex w-full items-center'>
+        <div className='flex w-1/4'>課程</div>
+        <div className='col-span-4 w-full'>
+          <Select className='w-full' value={formData.departmentID} onChange={handler('departmentID')}>
+            {departments.length > 1 ? departments.map((data) => (
+              <option key={data.id} value={data.id}>
+                {data.department}
+              </option>
+            )) : null}
+          </Select>
+        </div>
+      </div>
+      <div className='flex w-full items-center'>
+        <div className='flex w-1/4'>学年</div>
+        <div className='col-span-4 w-full'>
+          <Select className='w-full' value={formData.gradeID} onChange={handler('gradeID')}>
+            {grades.map((data) => (
+              <option key={data.id} value={data.id}>
+                {data.grade}
+              </option>
+            ))}
+          </Select>
+        </div>
+      </div>
+      <div className='flex w-full items-center'>
+        <div className='flex w-1/4'>電話番号</div>
+        <div className='col-span-4 w-full'>
+          <Input className='w-full' value={formData.tel} onChange={handler('tel')} />
+        </div>
+      </div>
+      <div className='flex w-full items-center'>
+        <div className='flex w-1/4'>メールアドレス</div>
+        <div className='col-span-4 w-full'>
+          <Input className='w-full' value={formData.mail} onChange={handler('mail')} />
+        </div>
+      </div>
+    </InformationPageLayout>
   );
 }

--- a/admin/next-project/seeft-admin/src/pages/users/index.tsx
+++ b/admin/next-project/seeft-admin/src/pages/users/index.tsx
@@ -35,7 +35,7 @@ export const getServerSideProps = async () => {
   };
 };
 
-export default function Uesrs(props: Props) {
+export default function Users(props: Props) {
   const { users, grades, departments, bureaus } = props;
   const router = useRouter();
 

--- a/admin/next-project/seeft-admin/src/pages/users/index.tsx
+++ b/admin/next-project/seeft-admin/src/pages/users/index.tsx
@@ -4,9 +4,10 @@ import { useRouter } from 'next/router';
 import { get } from '@api/api_methods';
 import { User, Grade, Department, Bureau } from "@type/common";
 import MainLayout from '@components/layout/MainLayout';
-import { MdEdit, MdDeleteForever } from "react-icons/md";
 import Button from '@components/common/Button';
 import { destroy } from '@api/user';
+import { DeleteButton, EditButton } from '@components/common';
+import ListPageLayout from '@components/layout/ListPageLayout';
 
 interface Props {
   users: User[];
@@ -43,7 +44,7 @@ export default function Users(props: Props) {
     router.push('users/add-user');
   }
 
-  const UserDetailPageRouter = (user: User) => {
+  const userDetailPageRouter = (user: User) => {
     router.push('users/' + user.id + '/detail-user');
   }
 
@@ -54,137 +55,124 @@ export default function Users(props: Props) {
   };
 
   return (
-    <MainLayout>
-      <div className='w-full h-full bg-white-0 flex-col p-8'>
-        <div className='items-center text-xl text-emphasis'>
-          ユーザー一覧
-        </div>
-        <div className='items-center'>
-          <div className='text-right pr-4'>
-            <Button className='bg-surface-2 border-accent-2 text-right text-emphasis pr-4 hover:bg-surface-1' onClick={addUserPageRouter}>
-              ユーザー追加
-            </Button>
-          </div>
-        </div>
-        <div className='p-5'>
-          <table className='mb-5 w-full table-auto border-collapse'>
-            <thead>
-              <tr>
-                <th className='w-1/12 border border-x-white-0 border-b-accent-1 border-t-white-0 py-3'>
-                  <p className='text-center text-sm text-emphasis'>所属局</p>
-                </th>
-                <th className='w-2/12 border border-x-white-0 border-b-accent-1 border-t-white-0 py-3'>
-                  <p className='text-center text-sm text-emphasis'>名前</p>
-                </th>
-                <th className='w-1/12 border border-x-white-0 border-b-accent-1 border-t-white-0 py-3'>
-                  <p className='text-center text-sm text-emphasis'>学年</p>
-                </th>
-                <th className='w-2/12 border border-x-white-0 border-b-accent-1 border-t-white-0 py-3'>
-                  <p className='text-center text-sm text-emphasis'>学科</p>
-                </th>
-                <th className='w-2/12 border border-x-white-0 border-b-accent-1 border-t-white-0 py-3'>
-                  <p className='text-center text-sm text-emphasis'>学籍番号</p>
-                </th>
-                <th className='w-2/12 border border-x-white-0 border-b-accent-1 border-t-white-0 py-3'>
-                  <p className='text-center text-sm text-emphasis'>電話番号</p>
-                </th>
-                <th className='w-1/12 border border-x-white-0 border-b-accent-1 border-t-white-0 py-3' />
-                <th className='w-1/12 border border-x-white-0 border-b-accent-1 border-t-white-0 py-3' />
-              </tr>
-            </thead>
-            <tbody className='border border-x-white-0 border-b-accent-1 border-t-white-0'>
-              {users ? users.map((user: User, index) => (
-                <tr key={user.id}>
-                  <td
-                    className={clsx(
-                      'px-1 py-2',
-                      index === 0 ? 'pb-3 pt-4' : 'py-3',
-                      index === users.length - 1 ? 'pb-4 pt-3' : 'border-b-accent-1 py-3',
-                    )}
-                  >
-                    <p className='text-center text-sm text-emphasis'>{bureaus.find((bureau: Bureau) => (bureau.id === user.bureauID))?.bureau}</p>
-                  </td>
-                  <td
-                    className={clsx(
-                      'px-1 py-2',
-                      index === 0 ? 'pb-3 pt-4' : 'py-3',
-                      index === users.length - 1 ? 'pb-4 pt-3' : 'border-b-accent-1 py-3',
-                    )}
-                  >
-                    <p className='text-center text-sm text-emphasis'>{user.name}</p>
-                  </td>
-                  <td
-                    className={clsx(
-                      'px-1 py-2',
-                      index === 0 ? 'pb-3 pt-4' : 'py-3',
-                      index === users.length - 1 ? 'pb-4 pt-3' : 'border-b-accent-1 py-3',
-                    )}
-                  >
-                    <p className='text-center text-sm text-emphasis'>{grades.length - 1 ? grades.find((grade: Grade) => (grade.id === user.gradeID))?.grade : "erorr"}</p>
-                  </td>
-                  <td
-                    className={clsx(
-                      'px-1 py-2',
-                      index === 0 ? 'pb-3 pt-4' : 'py-3',
-                      index === users.length - 1 ? 'pb-4 pt-3' : 'border-b-accent-1 py-3',
-                    )}
-                  >
-                    <p className='text-center text-sm text-emphasis'>{departments.length - 1 ? departments.find((department: Department) => (department.id === user.departmentID))?.department : "erorr"}</p>
-                  </td>
-                  <td
-                    className={clsx(
-                      'px-1 py-2',
-                      index === 0 ? 'pb-3 pt-4' : 'py-3',
-                      index === users.length - 1 ? 'pb-4 pt-3' : 'border-b-accent-1 py-3',
-                    )}
-                  >
-                    <p className='text-center text-sm text-emphasis'>{user.studentNumber}</p>
-                  </td>
-                  <td
-                    className={clsx(
-                      'px-1 py-2',
-                      index === 0 ? 'pb-3 pt-4' : 'py-3',
-                      index === users.length - 1 ? 'pb-4 pt-3' : 'border-b-accent-1 py-3',
-                    )}
-                  >
-                    <p className='text-center text-sm text-emphasis'>{user.tel}</p>
-                  </td>
-                  <td
-                    className={clsx(
-                      'px-1 py-2',
-                      index === 0 ? 'pb-3 pt-4' : 'py-3',
-                      index === users.length - 1 ? 'pb-4 pt-3' : 'border-b-accent-1 py-3',
-                    )}
-                  >
-                    <div className='flex justify-items-center gap-4 rounded-full hover:bg-accent-1'
-                      onClick={() => { UserDetailPageRouter(user) }}>
-                      <MdEdit />
-                      <p className='text-center text-sm text-emphasis'>
-                        編集
-                      </p>
-                    </div>
-                  </td>
-                  <td
-                    className={clsx(
-                      'px-1 py-2',
-                      index === 0 ? 'pb-3 pt-4' : 'py-3',
-                      index === users.length - 1 ? 'pb-4 pt-3' : 'border-b-accent-1 py-3',
-                    )}
-                  >
-                    <div className='flex justify-items-center gap-4 rounded-full hover:bg-accent-1'
-                      onClick={() => { destroyUserInformation(user); }}>
-                      <MdDeleteForever />
-                      <p className='text-center text-sm text-emphasis'>
-                        削除
-                      </p>
-                    </div>
-                  </td>
-                </tr>
-              )) : null}
-            </tbody>
-          </table>
+    <ListPageLayout title='ユーザー一覧'>
+      <div className='items-center'>
+        <div className='text-right pr-4'>
+          <Button className='bg-surface-2 border-accent-2 text-right text-emphasis pr-4 hover:bg-surface-1' onClick={addUserPageRouter}>
+            ユーザー追加
+          </Button>
         </div>
       </div>
-    </MainLayout >
+      <div className='p-5'>
+        <table className='mb-5 w-full table-auto border-collapse'>
+          <thead>
+            <tr>
+              <th className='w-1/12 border border-x-white-0 border-b-accent-1 border-t-white-0 py-3'>
+                <p className='text-center text-sm text-emphasis'>所属局</p>
+              </th>
+              <th className='w-2/12 border border-x-white-0 border-b-accent-1 border-t-white-0 py-3'>
+                <p className='text-center text-sm text-emphasis'>名前</p>
+              </th>
+              <th className='w-1/12 border border-x-white-0 border-b-accent-1 border-t-white-0 py-3'>
+                <p className='text-center text-sm text-emphasis'>学年</p>
+              </th>
+              <th className='w-2/12 border border-x-white-0 border-b-accent-1 border-t-white-0 py-3'>
+                <p className='text-center text-sm text-emphasis'>学科</p>
+              </th>
+              <th className='w-2/12 border border-x-white-0 border-b-accent-1 border-t-white-0 py-3'>
+                <p className='text-center text-sm text-emphasis'>学籍番号</p>
+              </th>
+              <th className='w-2/12 border border-x-white-0 border-b-accent-1 border-t-white-0 py-3'>
+                <p className='text-center text-sm text-emphasis'>電話番号</p>
+              </th>
+              <th className='w-1/12 border border-x-white-0 border-b-accent-1 border-t-white-0 py-3' />
+              <th className='w-1/12 border border-x-white-0 border-b-accent-1 border-t-white-0 py-3' />
+            </tr>
+          </thead>
+          <tbody className='border border-x-white-0 border-b-accent-1 border-t-white-0'>
+            {users ? users.map((user: User, index) => (
+              <tr key={user.id}>
+                <td
+                  className={clsx(
+                    'px-1 py-2',
+                    index === 0 ? 'pb-3 pt-4' : 'py-3',
+                    index === users.length - 1 ? 'pb-4 pt-3' : 'border-b-accent-1 py-3',
+                  )}
+                >
+                  <p className='text-center text-sm text-emphasis'>{bureaus.find((bureau: Bureau) => (bureau.id === user.bureauID))?.bureau}</p>
+                </td>
+                <td
+                  className={clsx(
+                    'px-1 py-2',
+                    index === 0 ? 'pb-3 pt-4' : 'py-3',
+                    index === users.length - 1 ? 'pb-4 pt-3' : 'border-b-accent-1 py-3',
+                  )}
+                >
+                  <p className='text-center text-sm text-emphasis'>{user.name}</p>
+                </td>
+                <td
+                  className={clsx(
+                    'px-1 py-2',
+                    index === 0 ? 'pb-3 pt-4' : 'py-3',
+                    index === users.length - 1 ? 'pb-4 pt-3' : 'border-b-accent-1 py-3',
+                  )}
+                >
+                  <p className='text-center text-sm text-emphasis'>{grades.length - 1 ? grades.find((grade: Grade) => (grade.id === user.gradeID))?.grade : "erorr"}</p>
+                </td>
+                <td
+                  className={clsx(
+                    'px-1 py-2',
+                    index === 0 ? 'pb-3 pt-4' : 'py-3',
+                    index === users.length - 1 ? 'pb-4 pt-3' : 'border-b-accent-1 py-3',
+                  )}
+                >
+                  <p className='text-center text-sm text-emphasis'>{departments.length - 1 ? departments.find((department: Department) => (department.id === user.departmentID))?.department : "erorr"}</p>
+                </td>
+                <td
+                  className={clsx(
+                    'px-1 py-2',
+                    index === 0 ? 'pb-3 pt-4' : 'py-3',
+                    index === users.length - 1 ? 'pb-4 pt-3' : 'border-b-accent-1 py-3',
+                  )}
+                >
+                  <p className='text-center text-sm text-emphasis'>{user.studentNumber}</p>
+                </td>
+                <td
+                  className={clsx(
+                    'px-1 py-2',
+                    index === 0 ? 'pb-3 pt-4' : 'py-3',
+                    index === users.length - 1 ? 'pb-4 pt-3' : 'border-b-accent-1 py-3',
+                  )}
+                >
+                  <p className='text-center text-sm text-emphasis'>{user.tel}</p>
+                </td>
+                <td
+                  className={clsx(
+                    'px-1 py-2',
+                    index === 0 ? 'pb-3 pt-4' : 'py-3',
+                    index === users.length - 1 ? 'pb-4 pt-3' : 'border-b-accent-1 py-3',
+                  )}
+                >
+                  <EditButton onClick={() => { userDetailPageRouter(user) }}>
+                    編集
+                  </EditButton>
+                </td>
+                <td
+                  className={clsx(
+                    'px-1 py-2',
+                    index === 0 ? 'pb-3 pt-4' : 'py-3',
+                    index === users.length - 1 ? 'pb-4 pt-3' : 'border-b-accent-1 py-3',
+                  )}
+                >
+                  <DeleteButton onClick={() => { destroyUserInformation(user) }} >
+                    削除
+                  </DeleteButton>
+                </td>
+              </tr>
+            )) : null}
+          </tbody>
+        </table>
+      </div>
+    </ListPageLayout>
   );
 }

--- a/admin/next-project/seeft-admin/src/type/common.ts
+++ b/admin/next-project/seeft-admin/src/type/common.ts
@@ -38,3 +38,12 @@ export interface Bureau {
   createdAt?: string;
   updatedAt?: string;
 }
+
+// Place(集合場所)
+export interface Place {
+  id: number;
+  place: string;
+  remark: string;
+  createdAt?: string;
+  updatedAt?: string;
+}

--- a/admin/next-project/seeft-admin/src/utils/api/place.ts
+++ b/admin/next-project/seeft-admin/src/utils/api/place.ts
@@ -1,0 +1,50 @@
+import { Place } from '@type/common';
+
+export const post = async (url: string, data: Place) => {
+  const place = data.place;
+  const remark = data.remark;
+  const postUrl = url +
+    '?place=' + place +
+    '&remark=' + remark;
+  const res = await fetch(postUrl, {
+    method: 'POST',
+    mode: 'cors',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(data),
+  });
+  return await res;
+  // return await res.json();
+};
+
+export const put = async (url: string, data: Place) => {
+  const place = data.place;
+  const remark = data.remark;
+  const putUrl = url +
+    '?place=' + place +
+    '&remark=' + remark;
+  const res = await fetch(putUrl, {
+    method: 'PUT',
+    mode: 'cors',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(data),
+  });
+  return await res.json();
+};
+
+export const destroy = async (url: string, data: Place) => {
+  const id = data.id
+  const destroyUrl = url + '?id=' + id;
+  const res = await fetch(destroyUrl, {
+    method: 'DELETE',
+    mode: 'cors',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(data),
+  });
+  return await res;
+};

--- a/api/lib/di/di.go
+++ b/api/lib/di/di.go
@@ -26,6 +26,7 @@ func InitializeServer() db.Client {
 	sessionRepository := repository.NewSessionRepository(client)
 	bureauRepository := repository.NewBureauRepository(client, crud)
 	gradeRepository := repository.NewGradeRepository(client, crud)
+	placeRepository := repository.NewPlaceRepository(client, crud)
 	departmentRepository := repository.NewDepartmentRepository(client, crud)
 	shiftRepository := repository.NewShiftRepository(client, crud)
 	taskRepository := repository.NewTaskRepository(client, crud)
@@ -39,6 +40,7 @@ func InitializeServer() db.Client {
 	mailAuthUseCase := usecase.NewAuthUseCase(userRepository, sessionRepository)
 	bureauUseCase := usecase.NewBureauUseCase(bureauRepository)
 	gradeUseCase := usecase.NewGradeUseCase(gradeRepository)
+	placeUseCase := usecase.NewPlaceUseCase(placeRepository)
 	departmentUseCase := usecase.NewDepartmentUseCase(departmentRepository)
 	shiftUseCase := usecase.NewShiftUseCase(shiftRepository, taskRepository, userRepository, yearRepository, dateRepository, timeRepository, weatherRepository)
 	taskUseCase := usecase.NewTaskUseCase(taskRepository)
@@ -50,6 +52,7 @@ func InitializeServer() db.Client {
 	mailAuthController := controller.NewMailAuthController(mailAuthUseCase)
 	bureauController := controller.NewBureauController(bureauUseCase)
 	gradeController := controller.NewGradeController(gradeUseCase)
+	placeController := controller.NewPlaceController(placeUseCase)
 	departmentController := controller.NewDepartmentController(departmentUseCase)
 	shiftContoller := controller.NewShiftController(shiftUseCase)
 	taskController := controller.NewTaskController(taskUseCase)
@@ -62,6 +65,7 @@ func InitializeServer() db.Client {
 		mailAuthController,
 		bureauController,
 		gradeController,
+		placeController,
 		departmentController,
 		shiftContoller,
 		taskController,

--- a/api/lib/entity/place.go
+++ b/api/lib/entity/place.go
@@ -1,0 +1,13 @@
+package entity
+
+import (
+	"time"
+)
+
+type Place struct {
+	ID			int 		`json:"id"`
+	Place 		string		`json:"place"`
+	Remark		string		`json:"remark"`
+	CreatedAt	time.Time	`json:"createdAt"`
+	UpdatedAt	time.Time	`json:"updatedAt"`
+}

--- a/api/lib/internals/controller/place_controller.go
+++ b/api/lib/internals/controller/place_controller.go
@@ -1,0 +1,74 @@
+package controller
+
+import (
+	"net/http"
+
+	"github.com/NUTFes/SeeFT/api/lib/usecase"
+	"github.com/labstack/echo/v4"
+)
+
+type placeController struct {
+	u usecase.PlaceUseCase
+}
+
+type PlaceController interface {
+	IndexPlace(echo.Context) error
+	ShowPlace(echo.Context) error
+	CreatePlace(echo.Context) error
+	UpdatePlace(echo.Context) error
+	DeletePlace(echo.Context) error
+}
+
+func NewPlaceController(u usecase.PlaceUseCase) PlaceController {
+	return &placeController{u}
+}
+
+func (b *placeController) IndexPlace(c echo.Context) error {
+	places, err := b.u.GetPlaces(c.Request().Context())
+	if err != nil {
+		return err
+	}
+	return c.JSON(http.StatusOK, places)
+}
+
+func (b *placeController) ShowPlace(c echo.Context) error {
+	id := c.Param("id")
+	place, err := b.u.GetPlaceByID(c.Request().Context(), id)
+	if err != nil {
+		return err
+	}
+	return c.JSON(http.StatusOK, place)
+}
+
+// Create
+func (u *placeController) CreatePlace(c echo.Context) error {
+	place := c.QueryParam("place")
+	remark := c.QueryParam("remark")
+	latastPlace, err := u.u.CreatePlace(c.Request().Context(), place, remark)
+	if err != nil {
+		return err
+	}
+	return c.JSON(http.StatusCreated, latastPlace)
+}
+
+// Update
+func (u *placeController) UpdatePlace(c echo.Context) error {
+	id := c.Param("id")
+	place := c.QueryParam("place")
+	remark := c.QueryParam("remark")
+	updatedPlace, err := u.u.UpdatePlace(c.Request().Context(), id, place, remark)
+	if err != nil {
+		return err
+	}
+	return c.JSON(http.StatusOK, updatedPlace)
+}
+
+// Destroy
+func (u *placeController) DeletePlace(c echo.Context) error {
+	id := c.QueryParam("id")
+	err := u.u.DeletePlace(c.Request().Context(), id)
+	if err != nil {
+		return err
+	}
+	return c.String(http.StatusOK, "Destroy Place")
+}

--- a/api/lib/internals/repository/place_repository.go
+++ b/api/lib/internals/repository/place_repository.go
@@ -1,0 +1,72 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/NUTFes/SeeFT/api/lib/externals/db"
+	"github.com/NUTFes/SeeFT/api/lib/internals/repository/abstract"
+)
+
+type placeRepository struct {
+	client db.Client
+	crud   abstract.Crud
+}
+
+type PlaceRepository interface {
+	All(context.Context) (*sql.Rows, error)
+	Find(context.Context, string) (*sql.Row, error)
+	Create(context.Context, string, string) error
+	Update(context.Context, string, string, string) error
+	Destroy(context.Context, string) error
+	FindNewRecord(context.Context) (*sql.Row, error)
+}
+
+func NewPlaceRepository(c db.Client, ac abstract.Crud) PlaceRepository {
+	return &placeRepository{c, ac}
+}
+
+// 全件取得
+func (b *placeRepository) All(c context.Context) (*sql.Rows, error) {
+	query := "SELECT * FROM places"
+	return b.crud.Read(c, query)
+}
+
+// 1件取得
+func (b *placeRepository) Find(c context.Context, id string) (*sql.Row, error) {
+	query := "SELECT * FROM places WHERE id =" + id
+	return b.crud.ReadByID(c, query)
+}
+
+// 作成
+func (b *placeRepository) Create(c context.Context, name string, remark string) error {
+	query := "INSERT INTO places (place, remark) VALUES ('" + name + "', '" + remark +"')"
+	return b.crud.UpdateDB(c, query)
+}
+
+// 編集
+func (b *placeRepository) Update(c context.Context, id string, name string, remark string) error {
+	query := "UPDATE places SET (place, remark) = ('" + name + "', '" + remark +"') WHERE id = " + id
+	return b.crud.UpdateDB(c, query)
+}
+
+// 削除
+func (b *placeRepository) Destroy(c context.Context, id string) error {
+	query := "DELETE FROM places WHERE id =" + id
+	return b.crud.UpdateDB(c, query)
+}
+
+// 最新のgradeを取得する
+func (b *placeRepository) FindNewRecord(c context.Context) (*sql.Row, error) {
+	query := `
+		SELECT
+			*
+		FROM
+			places
+		ORDER BY
+			id
+		DESC LIMIT 1
+	`
+	return b.crud.ReadByID(c, query)
+}
+

--- a/api/lib/router/router.go
+++ b/api/lib/router/router.go
@@ -11,6 +11,7 @@ type router struct {
 	mailAuthController		  controller.MailAuthController
 	bureauController          controller.BureauController
 	gradeController						controller.GradeController
+	placeController						controller.PlaceController
 	departmentController      controller.DepartmentController
 	shiftController 		  		controller.ShiftController
 	taskController			  		controller.TaskController
@@ -27,6 +28,7 @@ func NewRouter(
 	mailAuthController controller.MailAuthController,
 	bureauController controller.BureauController,
 	gradeController controller.GradeController,
+	placeController controller.PlaceController,
 	departmentController controller.DepartmentController,
 	shiftContoller controller.ShiftController,
 	taskController controller.TaskController,
@@ -38,6 +40,7 @@ func NewRouter(
 		mailAuthController,
 		bureauController,
 		gradeController,
+		placeController,
 		departmentController,
 		shiftContoller,
 		taskController,
@@ -62,6 +65,13 @@ func (r router) ProvideRouter(e *echo.Echo) {
 	// gradeのRoute
 	e.GET("/grades", r.gradeController.IndexGrade)
 	e.GET("/grades/:id", r.gradeController.ShowGrade)
+
+	// placeのRoute
+	e.GET("/places", r.placeController.IndexPlace)
+	e.GET("/places/:id", r.placeController.ShowPlace)
+	e.POST("/places", r.placeController.CreatePlace)
+	e.PUT("/places/:id", r.placeController.UpdatePlace)
+	e.DELETE("/places", r.placeController.DeletePlace)
 
 	// departmentのRoute
 	e.GET("/departments", r.departmentController.IndexDepartment)

--- a/api/lib/usecase/place_usecase.go
+++ b/api/lib/usecase/place_usecase.go
@@ -1,0 +1,124 @@
+package usecase
+
+import (
+	"context"
+
+	rep "github.com/NUTFes/SeeFT/api/lib/internals/repository"
+	"github.com/NUTFes/SeeFT/api/lib/entity"
+	"github.com/pkg/errors"
+)
+
+type placeUseCase struct {
+  rep rep.PlaceRepository
+}
+
+type PlaceUseCase interface {
+  GetPlaces(context.Context) ([]entity.Place, error)
+  GetPlaceByID(context.Context, string) (entity.Place, error) 
+	CreatePlace(context.Context, string, string) (entity.Place, error)
+  UpdatePlace(context.Context, string, string, string) (entity.Place, error)
+  DeletePlace(context.Context, string) error
+}
+
+func NewPlaceUseCase(rep rep.PlaceRepository) PlaceUseCase {
+  return &placeUseCase{rep}
+}
+
+func (u *placeUseCase) GetPlaces(c context.Context) ([]entity.Place, error) {
+
+  place := entity.Place{}
+  var places []entity.Place
+
+  // クエリー実行
+	rows, err := u.rep.All(c)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		err := rows.Scan(
+			&place.ID,
+			&place.Place,
+			&place.Remark,
+			&place.CreatedAt,
+			&place.UpdatedAt,
+		)
+
+		if err != nil {
+			return nil, errors.Wrapf(err, "cannot connect SQL")
+		}
+
+		places = append(places, place)
+	}
+	return places, nil
+}
+
+func (u *placeUseCase) GetPlaceByID(c context.Context, id string) (entity.Place, error) {
+	var place entity.Place
+	row, err := u.rep.Find(c, id)
+	err = row.Scan(
+		&place.ID,
+		&place.Place,
+		&place.Remark,
+		&place.CreatedAt,
+		&place.UpdatedAt,
+	)
+	if err != nil {
+		return place, err
+	}
+	return place, nil
+}
+
+func (u *placeUseCase) CreatePlace(c context.Context, place string, remark string) (entity.Place, error) {
+	latastPlace := entity.Place{}
+	err := u.rep.Create(c, place, remark)
+	row, err := u.rep.FindNewRecord(c)
+	err = row.Scan(
+		&latastPlace.ID,
+		&latastPlace.Place,
+		&latastPlace.Remark,
+		&latastPlace.CreatedAt,
+		&latastPlace.UpdatedAt,
+	)
+	if err != nil {
+		return latastPlace, err
+	}
+	return latastPlace, err
+}
+
+func (u *placeUseCase) UpdatePlace(c context.Context, id string, placeName string, remark string) (entity.Place, error) {
+	updatedPlace := entity.Place{}
+	var place entity.Place
+
+	row, err := u.rep.Find(c, id)
+	err = row.Scan(
+		&place.ID,
+		&place.Place,
+		&place.Remark,
+		&place.CreatedAt,
+		&place.UpdatedAt,
+	)
+	if err != nil {
+		return place, err
+	}
+
+	u.rep.Update(c, id, placeName, remark)
+	row, err = u.rep.Find(c, id)
+	err = row.Scan(
+		&updatedPlace.ID,
+		&updatedPlace.Place,
+		&updatedPlace.Remark,
+		&updatedPlace.CreatedAt,
+		&updatedPlace.UpdatedAt,
+	)
+	if err != nil {
+		return updatedPlace, err
+	}
+	return updatedPlace, nil
+}
+
+func (u *placeUseCase) DeletePlace(c context.Context, id string) error {
+	err := u.rep.Destroy(c, id)
+	return err
+}

--- a/mobile/Dockerfile
+++ b/mobile/Dockerfile
@@ -1,4 +1,5 @@
-FROM ubuntu:latest
+FROM ubuntu:20.04
+RUN ln -fs /usr/share/zoneinfo/Asia/Tokyo /etc/localtime
 
 # 必要なツールをインストールします。
 RUN apt-get update && apt-get install -y \
@@ -7,14 +8,17 @@ RUN apt-get update && apt-get install -y \
     unzip \
     xz-utils \
     libglu1-mesa \
+    curl \
     python3 \
     python3-pip
 
 # Flutter SDKをダウンロードしてパスに追加します。
-WORKDIR /opt
-RUN wget https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_3.10.6-stable.tar.xz
-RUN tar xf flutter_linux_3.10.6-stable.tar.xz
-ENV PATH="$PATH:/opt/flutter/bin"
+ARG FLUTTER_SDK=/flutter
+ENV FLUTTER_VERSION=3.10.6
+RUN git clone https://github.com/flutter/flutter.git $FLUTTER_SDK
+RUN cd $FLUTTER_SDK && git fetch && git checkout $FLUTTER_VERSION
+ENV PATH="${PATH}:$FLUTTER_SDK/bin:$FLUTTER_SDK/bin/cache/dart-sdk/bin"
+RUN chmod -R 777 $FLUTTER_SDK
 
 # 新しいユーザーを作成します。
 RUN useradd -ms /bin/bash flutteruser
@@ -23,6 +27,7 @@ RUN useradd -ms /bin/bash flutteruser
 COPY . /home/flutteruser/seeft_mobile
 RUN chown -R flutteruser:flutteruser /home/flutteruser/seeft_mobile
 RUN chmod -R 777 /home/flutteruser/seeft_mobile
+RUN chown -R flutteruser:flutteruser $FLUTTER_SDK
 
 
 USER flutteruser

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -18,12 +18,11 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.12.0 <3.22.0"
 
 dependencies:
   flutter:
     sdk: flutter
-
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/mysql/db/create1Place.sql
+++ b/mysql/db/create1Place.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS places (
+    id SERIAL PRIMARY KEY,
+    place VARCHAR(255) NOT NULL,
+    remark VARCHAR(255),
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'update_plcaes_timestamp') THEN
+        CREATE TRIGGER update_grades_timestamp
+        BEFORE UPDATE ON places
+        FOR EACH ROW
+        EXECUTE FUNCTION update_updated_at_column();
+    END IF;
+END $$;

--- a/mysql/db/seed.sql
+++ b/mysql/db/seed.sql
@@ -167,6 +167,11 @@ VALUES
   ('量子・原子力統合工学分野/原子力システム安全工学専攻'),
   ('技術科学イノベーション');
 
+INSERT INTO places
+  (place, remark)
+VALUES
+  ('未定', '本部に指示を聞いてください');
+
 INSERT INTO users
   (name,mail,grade_id,department_id,bureau_id,role_id,student_number,tel,password)
 VALUES


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #59

# 概要
<!-- 開発内容の概要を記載 -->
以下を実装
- 集合場所一覧ページ
- 集合場所追加ページ
- 集合場所編集ページ
- 集合場所削除機能

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
![スクリーンショット (88)](https://github.com/NUTFes/SeeFT/assets/68796591/0f818cd7-f906-4ffa-8f4c-e6fb797a66b6)


# テスト項目
<!-- テストしてほしい内容を記載 -->
- [x] `dokcer compose down -v`でコンテナを落とす
- [x] `make build`でコンテナ構築
- [x] `make up`で実行
- [x] `localhost:3000/places`にアクセスし、集合場所一覧ページが表示されるか
- [x] 集合場所追加のボタンを押下
- [x] `localhost:3000/places/add-place`に遷移し、集合場所追加画面に移行するか
- [x] 集合場所一覧ページの編集ボタンで編集画面に遷移するか
- [x] 集合場所の情報を書き換えたときに反映されるか
- [x] 集合場所一覧ページの削除ボタンでユーザー集合場所が削除されるか 

# 備考
自分の環境でFlutterのbuildが、うまくいかなかったのでdokcerfileを書き換えています