### PR TITLE
[Feat]前後のシフトのメンバー表示

### DIFF
--- a/mobile/lib/widgets/drawer.dart
+++ b/mobile/lib/widgets/drawer.dart
@@ -54,14 +54,14 @@ class ApplicationDrawer {
                 context, '/users_page', (Route<dynamic> route) => false)
           },
         ),
-        ListTile(
-          title: Text("タイムスケジュール"),
-          leading: Icon(Icons.schedule),
-          onTap: () => {
-            Navigator.pushNamedAndRemoveUntil(
-                context, '/schedule_page', (Route<dynamic> route) => false)
-          },
-        ),
+        // ListTile(
+        //   title: Text("タイムスケジュール"),
+        //   leading: Icon(Icons.schedule),
+        //   onTap: () => {
+        //     Navigator.pushNamedAndRemoveUntil(
+        //         context, '/schedule_page', (Route<dynamic> route) => false)
+        //   },
+        // ),
         ListTile(
           title: Text("本部連絡先"),
           leading: Icon(Icons.contact_phone),

--- a/mobile/lib/widgets/shift_dialog.dart
+++ b/mobile/lib/widgets/shift_dialog.dart
@@ -57,7 +57,7 @@ openShiftDialog(
 
   // 1つ前の時間のシフトのメンバー
   var resBeforeUsers = '';
-  if (time["id"] != 0) {
+  if (time["id"] > 1) {
     var beforeRes = await api.getUsersByShift(
         task["id"].toString(),
         year["id"].toString(),

--- a/mobile/lib/widgets/shift_dialog.dart
+++ b/mobile/lib/widgets/shift_dialog.dart
@@ -37,6 +37,7 @@ openShiftDialog(
   // var resPresident = res["superviser"];
   // var resPresidentTel = res["TEL"];
 
+  // 現在のシフトのメンバー
   var res = await api.getUsersByShift(
       task["id"].toString(),
       year["id"].toString(),
@@ -53,6 +54,44 @@ openShiftDialog(
     resUsersList.add(res["users"][index]["name"].toString());
   }
   var resUsers = resUsersList.join(",");
+
+  // 1つ前の時間のシフトのメンバー
+  var resBeforeUsers = '';
+  if (time["id"] != 0) {
+    var beforeRes = await api.getUsersByShift(
+        task["id"].toString(),
+        year["id"].toString(),
+        date["id"].toString(),
+        (time["id"] - 1).toString(),
+        weather["id"].toString());
+    List<String> resBeforeUsersList = <String>[];
+    var resBeforeUsersNumber = beforeRes["users"].length;
+    for (var index = 0; index < resBeforeUsersNumber; index++) {
+      resBeforeUsersList.add(beforeRes["users"][index]["name"].toString());
+    }
+    resBeforeUsers = resBeforeUsersList.join(",");
+  } else {
+    resBeforeUsers = 'none';
+  }
+
+  // 1つ後の時間のシフトのメンバー
+  var resAfterUsers = '';
+  if (time["id"] != 96) {
+    var afterRes = await api.getUsersByShift(
+        task["id"].toString(),
+        year["id"].toString(),
+        date["id"].toString(),
+        (time["id"] + 1).toString(),
+        weather["id"].toString());
+    List<String> resAfterUsersList = <String>[];
+    var resAfterUsersNumber = afterRes["users"].length;
+    for (var index = 0; index < resAfterUsersNumber; index++) {
+      resAfterUsersList.add(afterRes["users"][index]["name"].toString());
+    }
+    resAfterUsers = resAfterUsersList.join(",");
+  } else {
+    resAfterUsers = 'none';
+  }
 
   showDialog(
     context: context,
@@ -99,6 +138,16 @@ openShiftDialog(
                     leading: Icon(Icons.group),
                     title: Text("メンバー"),
                     subtitle: Text(resUsers),
+                  ),
+                  ListTile(
+                    leading: Icon(Icons.group),
+                    title: Text("前のメンバー"),
+                    subtitle: Text(resBeforeUsers),
+                  ),
+                  ListTile(
+                    leading: Icon(Icons.group),
+                    title: Text("次のメンバー"),
+                    subtitle: Text(resAfterUsers),
                   ),
                 ],
               ),


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #74

# 概要
<!-- 開発内容の概要を記載 -->
モバイルのシフトの前後のメンバーをモーダルに表示
＊引継ぎしやすくするための実装

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
![スクリーンショット 2024-08-19 161944](https://github.com/user-attachments/assets/222856de-30c6-42c9-93d7-6d57bd47a124)


# テスト項目
<!-- テストしてほしい内容を記載 -->
- `make build`をしてから、`make up`で立ち上げる
- `localhost:3000'にアクセスし、webアプリの方でシフトを編集する
- `localhost:45029`にアクセスし、スマホアプリを起動する
- シフトのモーダルを表示させ、前後のメンバーが表示されているか確認する

# 備考