### PR TITLE
[add]シフトページで局順にソートするように変更

### DIFF
--- a/admin/next-project/seeft-admin/src/pages/shifts/index.tsx
+++ b/admin/next-project/seeft-admin/src/pages/shifts/index.tsx
@@ -115,7 +115,7 @@ export default function Users(props: Props) {
   }, [selectedBureau])
 
   const filteredUsers = useMemo(() => {
-    return filteredBureau === 0 ? users
+    return filteredBureau === 0 ? users.sort((a: User, b: User) => (a.bureauID - b.bureauID))
       : users.filter((user: User) => (
         user.bureauID === filteredBureau
       ))

--- a/admin/next-project/seeft-admin/src/pages/tasks/index.tsx
+++ b/admin/next-project/seeft-admin/src/pages/tasks/index.tsx
@@ -70,7 +70,7 @@ export default function Users(props: Props) {
     <ListPageLayout title='タスク一覧'>
       <div className='items-center'>
         <div className='w-full flex justify-center items-center gap-6 p-1 '>
-          <div className='w-1/6'>
+          <div className='w-1/6 ml-auto'>
             <Select className="w-full" value={filteredBureau} onChange={filterBureauHandler()}>
               <option key={0} value={0}>全局</option>
               {bureaus.map((data) => (
@@ -80,7 +80,7 @@ export default function Users(props: Props) {
               ))}
             </Select>
           </div>
-          <div className='text-right pr-4'>
+          <div className='text-right pr-4 ml-auto'>
             <Button className='bg-surface-2 border-accent-2 text-right text-emphasis pr-4 hover:bg-surface-1' onClick={addTaskPageRouter}>
               タスク追加
             </Button>

--- a/admin/next-project/seeft-admin/src/pages/tasks/index.tsx
+++ b/admin/next-project/seeft-admin/src/pages/tasks/index.tsx
@@ -4,8 +4,9 @@ import { useRouter } from 'next/router';
 import { get } from '@api/api_methods';
 import { Task, User, Place, Bureau } from "@type/common";
 import { destroy } from '@api/task';
-import { Button, DeleteButton, EditButton } from '@components/common';
+import { Button, DeleteButton, EditButton, Select } from '@components/common';
 import ListPageLayout from '@components/layout/ListPageLayout';
+import { useMemo, useState } from 'react';
 
 interface Props {
   tasks: Task[];
@@ -36,6 +37,7 @@ export const getServerSideProps = async () => {
 
 export default function Users(props: Props) {
   const { tasks, users, places, bureaus } = props;
+  const [filteredBureau, setFilteredBureau] = useState<number>(0);
   const router = useRouter();
 
   const addTaskPageRouter = () => {
@@ -51,14 +53,38 @@ export default function Users(props: Props) {
     await destroy(destroyTaskInformationUrl, data);
     router.reload();
   };
+  
+  const filterBureauHandler = () =>
+    (e: React.ChangeEvent<HTMLSelectElement>) => {
+      setFilteredBureau(Number(e.target.value));
+    };
+
+  const filteredTasks = useMemo(() => {
+    return filteredBureau === 0 ? tasks.sort((a: Task, b: Task) => a.bureauID - b.bureauID)
+      : tasks.filter((task: Task) => (
+        task.bureauID === filteredBureau
+      ))
+  }, [filteredBureau]);
 
   return (
     <ListPageLayout title='タスク一覧'>
       <div className='items-center'>
-        <div className='text-right pr-4'>
-          <Button className='bg-surface-2 border-accent-2 text-right text-emphasis pr-4 hover:bg-surface-1' onClick={addTaskPageRouter}>
-            タスク追加
-          </Button>
+        <div className='w-full flex justify-center items-center gap-6 p-1 '>
+          <div className='w-1/6'>
+            <Select className="w-full" value={filteredBureau} onChange={filterBureauHandler()}>
+              <option key={0} value={0}>全局</option>
+              {bureaus.map((data) => (
+                <option key={data.id} value={data.id}>
+                  {data.bureau}
+                </option>
+              ))}
+            </Select>
+          </div>
+          <div className='text-right pr-4'>
+            <Button className='bg-surface-2 border-accent-2 text-right text-emphasis pr-4 hover:bg-surface-1' onClick={addTaskPageRouter}>
+              タスク追加
+            </Button>
+          </div>
         </div>
       </div>
       <div className='p-5'>
@@ -91,13 +117,13 @@ export default function Users(props: Props) {
             </tr>
           </thead>
           <tbody className='border border-x-white-0 border-b-accent-1 border-t-white-0'>
-            {tasks ? tasks.map((task: Task, index) => (
+            {filteredTasks ? filteredTasks.map((task: Task, index) => (
               <tr key={task.id}>
                 <td
                   className={clsx(
                     'px-1 py-2',
                     index === 0 ? 'pb-3 pt-4' : 'py-3',
-                    index === users.length - 1 ? 'pb-4 pt-3' : 'border-b-accent-1 py-3',
+                    index === filteredTasks.length - 1 ? 'pb-4 pt-3' : 'border-b-accent-1 py-3',
                   )}
                 >
                   <p className='text-center text-sm text-emphasis'>{task.task}</p>
@@ -106,7 +132,7 @@ export default function Users(props: Props) {
                   className={clsx(
                     'px-1 py-2',
                     index === 0 ? 'pb-3 pt-4' : 'py-3',
-                    index === users.length - 1 ? 'pb-4 pt-3' : 'border-b-accent-1 py-3',
+                    index === filteredTasks.length - 1 ? 'pb-4 pt-3' : 'border-b-accent-1 py-3',
                   )}
                 >
                   <p className='text-center text-sm text-emphasis'>{places.find((place: Place) => { place.id === task.placeID })?.place}</p>
@@ -115,7 +141,7 @@ export default function Users(props: Props) {
                   className={clsx(
                     'px-1 py-2',
                     index === 0 ? 'pb-3 pt-4' : 'py-3',
-                    index === users.length - 1 ? 'pb-4 pt-3' : 'border-b-accent-1 py-3',
+                    index === filteredTasks.length - 1 ? 'pb-4 pt-3' : 'border-b-accent-1 py-3',
                   )}
                 >
                   <p className='text-center text-sm text-emphasis'>{task.url}</p>
@@ -124,7 +150,7 @@ export default function Users(props: Props) {
                   className={clsx(
                     'px-1 py-2',
                     index === 0 ? 'pb-3 pt-4' : 'py-3',
-                    index === users.length - 1 ? 'pb-4 pt-3' : 'border-b-accent-1 py-3',
+                    index === filteredTasks.length - 1 ? 'pb-4 pt-3' : 'border-b-accent-1 py-3',
                   )}
                 >
                   <p className='text-center text-sm text-emphasis'>{bureaus.length ? bureaus.find((bureau: Bureau) => (bureau.id === task.bureauID))?.bureau : "erorr"}</p>
@@ -133,7 +159,7 @@ export default function Users(props: Props) {
                   className={clsx(
                     'px-1 py-2',
                     index === 0 ? 'pb-3 pt-4' : 'py-3',
-                    index === users.length - 1 ? 'pb-4 pt-3' : 'border-b-accent-1 py-3',
+                    index === filteredTasks.length - 1 ? 'pb-4 pt-3' : 'border-b-accent-1 py-3',
                   )}
                 >
                   <p className='text-center text-sm text-emphasis'>{task.maxMember}</p>
@@ -142,7 +168,7 @@ export default function Users(props: Props) {
                   className={clsx(
                     'px-1 py-2',
                     index === 0 ? 'pb-3 pt-4' : 'py-3',
-                    index === users.length - 1 ? 'pb-4 pt-3' : 'border-b-accent-1 py-3',
+                    index === filteredTasks.length - 1 ? 'pb-4 pt-3' : 'border-b-accent-1 py-3',
                   )}
                 >
                   <div

--- a/admin/next-project/seeft-admin/src/pages/users/index.tsx
+++ b/admin/next-project/seeft-admin/src/pages/users/index.tsx
@@ -72,7 +72,7 @@ export default function Users(props: Props) {
     <ListPageLayout title='ユーザー一覧'>
       <div className='items-center'>
         <div className='w-full flex justify-center items-center gap-6 p-1 '>
-          <div className='w-1/6'>
+          <div className='w-1/6 ml-auto'>
             <Select className="w-full" value={filteredBureau} onChange={filterBureauHandler()}>
               <option key={0} value={0}>全局</option>
               {bureaus.map((data) => (
@@ -82,7 +82,7 @@ export default function Users(props: Props) {
               ))}
             </Select>
           </div>
-          <div className='text-right pr-4'>
+          <div className='text-right pr-4 ml-auto'>
             <Button className='bg-surface-2 border-accent-2 text-right text-emphasis pr-4 hover:bg-surface-1' onClick={addUserPageRouter}>
               ユーザー追加
             </Button>

--- a/admin/next-project/seeft-admin/src/pages/users/index.tsx
+++ b/admin/next-project/seeft-admin/src/pages/users/index.tsx
@@ -6,8 +6,9 @@ import { User, Grade, Department, Bureau } from "@type/common";
 import MainLayout from '@components/layout/MainLayout';
 import Button from '@components/common/Button';
 import { destroy } from '@api/user';
-import { DeleteButton, EditButton } from '@components/common';
+import { DeleteButton, EditButton, Select } from '@components/common';
 import ListPageLayout from '@components/layout/ListPageLayout';
+import { useMemo, useState } from 'react';
 
 interface Props {
   users: User[];
@@ -38,6 +39,7 @@ export const getServerSideProps = async () => {
 
 export default function Users(props: Props) {
   const { users, grades, departments, bureaus } = props;
+  const [filteredBureau, setFilteredBureau] = useState<number>(0);
   const router = useRouter();
 
   const addUserPageRouter = () => {
@@ -54,13 +56,37 @@ export default function Users(props: Props) {
     router.reload();
   };
 
+  const filterBureauHandler = () =>
+    (e: React.ChangeEvent<HTMLSelectElement>) => {
+      setFilteredBureau(Number(e.target.value));
+    };
+
+  const filteredUsers = useMemo(() => {
+    return filteredBureau === 0 ? users.sort((a: User, b: User) => a.bureauID - b.bureauID)
+      : users.filter((user: User) => (
+        user.bureauID === filteredBureau
+      ))
+  }, [filteredBureau]);
+  
   return (
     <ListPageLayout title='ユーザー一覧'>
       <div className='items-center'>
-        <div className='text-right pr-4'>
-          <Button className='bg-surface-2 border-accent-2 text-right text-emphasis pr-4 hover:bg-surface-1' onClick={addUserPageRouter}>
-            ユーザー追加
-          </Button>
+        <div className='w-full flex justify-center items-center gap-6 p-1 '>
+          <div className='w-1/6'>
+            <Select className="w-full" value={filteredBureau} onChange={filterBureauHandler()}>
+              <option key={0} value={0}>全局</option>
+              {bureaus.map((data) => (
+                <option key={data.id} value={data.id}>
+                  {data.bureau}
+                </option>
+              ))}
+            </Select>
+          </div>
+          <div className='text-right pr-4'>
+            <Button className='bg-surface-2 border-accent-2 text-right text-emphasis pr-4 hover:bg-surface-1' onClick={addUserPageRouter}>
+              ユーザー追加
+            </Button>
+          </div>
         </div>
       </div>
       <div className='p-5'>
@@ -90,13 +116,13 @@ export default function Users(props: Props) {
             </tr>
           </thead>
           <tbody className='border border-x-white-0 border-b-accent-1 border-t-white-0'>
-            {users ? users.map((user: User, index) => (
+            {filteredUsers ? filteredUsers.map((user: User, index) => (
               <tr key={user.id}>
                 <td
                   className={clsx(
                     'px-1 py-2',
                     index === 0 ? 'pb-3 pt-4' : 'py-3',
-                    index === users.length - 1 ? 'pb-4 pt-3' : 'border-b-accent-1 py-3',
+                    index === filteredUsers.length - 1 ? 'pb-4 pt-3' : 'border-b-accent-1 py-3',
                   )}
                 >
                   <p className='text-center text-sm text-emphasis'>{bureaus.find((bureau: Bureau) => (bureau.id === user.bureauID))?.bureau}</p>
@@ -105,7 +131,7 @@ export default function Users(props: Props) {
                   className={clsx(
                     'px-1 py-2',
                     index === 0 ? 'pb-3 pt-4' : 'py-3',
-                    index === users.length - 1 ? 'pb-4 pt-3' : 'border-b-accent-1 py-3',
+                    index === filteredUsers.length - 1 ? 'pb-4 pt-3' : 'border-b-accent-1 py-3',
                   )}
                 >
                   <p className='text-center text-sm text-emphasis'>{user.name}</p>
@@ -114,7 +140,7 @@ export default function Users(props: Props) {
                   className={clsx(
                     'px-1 py-2',
                     index === 0 ? 'pb-3 pt-4' : 'py-3',
-                    index === users.length - 1 ? 'pb-4 pt-3' : 'border-b-accent-1 py-3',
+                    index === filteredUsers.length - 1 ? 'pb-4 pt-3' : 'border-b-accent-1 py-3',
                   )}
                 >
                   <p className='text-center text-sm text-emphasis'>{grades.length - 1 ? grades.find((grade: Grade) => (grade.id === user.gradeID))?.grade : "erorr"}</p>
@@ -123,7 +149,7 @@ export default function Users(props: Props) {
                   className={clsx(
                     'px-1 py-2',
                     index === 0 ? 'pb-3 pt-4' : 'py-3',
-                    index === users.length - 1 ? 'pb-4 pt-3' : 'border-b-accent-1 py-3',
+                    index === filteredUsers.length - 1 ? 'pb-4 pt-3' : 'border-b-accent-1 py-3',
                   )}
                 >
                   <p className='text-center text-sm text-emphasis'>{departments.length - 1 ? departments.find((department: Department) => (department.id === user.departmentID))?.department : "erorr"}</p>
@@ -132,7 +158,7 @@ export default function Users(props: Props) {
                   className={clsx(
                     'px-1 py-2',
                     index === 0 ? 'pb-3 pt-4' : 'py-3',
-                    index === users.length - 1 ? 'pb-4 pt-3' : 'border-b-accent-1 py-3',
+                    index === filteredUsers.length - 1 ? 'pb-4 pt-3' : 'border-b-accent-1 py-3',
                   )}
                 >
                   <p className='text-center text-sm text-emphasis'>{user.studentNumber}</p>
@@ -141,7 +167,7 @@ export default function Users(props: Props) {
                   className={clsx(
                     'px-1 py-2',
                     index === 0 ? 'pb-3 pt-4' : 'py-3',
-                    index === users.length - 1 ? 'pb-4 pt-3' : 'border-b-accent-1 py-3',
+                    index === filteredUsers.length - 1 ? 'pb-4 pt-3' : 'border-b-accent-1 py-3',
                   )}
                 >
                   <p className='text-center text-sm text-emphasis'>{user.tel}</p>
@@ -150,7 +176,7 @@ export default function Users(props: Props) {
                   className={clsx(
                     'px-1 py-2',
                     index === 0 ? 'pb-3 pt-4' : 'py-3',
-                    index === users.length - 1 ? 'pb-4 pt-3' : 'border-b-accent-1 py-3',
+                    index === filteredUsers.length - 1 ? 'pb-4 pt-3' : 'border-b-accent-1 py-3',
                   )}
                 >
                   <EditButton onClick={() => { userDetailPageRouter(user) }}>


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
#80, #83
<!-- 対応したIssue番号を記載 -->
resolve #80, #83

# 概要
<!-- 開発内容の概要を記載 -->
- 80: シフト編集画面の一覧でユーザーをデフォルトで所属局でソートするようにする
- 83: タスク画面とユーザ画面にて、ユーザーを所属局でソートするようにする

変更ファイル
- 80: admin/next-project/seeft-admin/src/pages/shifts/index.tsx
- 83: admin/next-project/seeft-admin/src/pages/tasks/index.tsx
- 83: admin/next-project/seeft-admin/src/pages/users/index.tsx

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->

80: 以下のようになっていればOK（名前は追加順）
- シフト画面
![image](https://github.com/user-attachments/assets/345e9f2a-ce7d-4990-944a-57254985e17d)

83: 以下のようになっていればOK
- ユーザー画面
![image](https://github.com/user-attachments/assets/36d18538-b528-421b-9899-84d0f2524791)
- タスク画面
![image](https://github.com/user-attachments/assets/70fe5ca3-c0fb-4c29-a9df-414a08797382)


# テスト項目
<!-- テストしてほしい内容を記載 -->
- make upしてlocalhost:3000にアクセス
- 80: ユーザーを追加して、シフト画面でユーザが局順にソートされているかを確認
- 83: ユーザーを追加して、ユーザ画面でユーザが局順にソートされているかを確認
- 83: タスクを追加して、タスク画面でタスクが局順にソートされているかを確認
- 83: ユーザ画面でユーザを局でフィルタリングできるか
- 83: タスク画面でタスクを局でフィルタリングできるか

# 備考
- issue83のブランチを切るのを忘れました・・・