### PR TITLE
[feat]シフトを表示する高さをscreenに変更

### DIFF
--- a/admin/next-project/seeft-admin/src/pages/shifts/index.tsx
+++ b/admin/next-project/seeft-admin/src/pages/shifts/index.tsx
@@ -268,7 +268,7 @@ export default function Users(props: Props) {
             <FaChevronRight />
           </div>
         </div>
-        <div className='max-h-64 px-2 pb-2 overflow-y-auto select-none'>
+        <div className='h-screen px-2 pb-2 overflow-y-auto select-none'>
           <table className='table-fixed mb-5 w-full border-collapse'>
             <thead className='sticky top-0 z-10'>
               <tr>


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #99 

# 概要
<!-- 開発内容の概要を記載 -->
シフトを表示する範囲をmax-h-64 -> h-screenに変更

変更ファイル
- admin/next-project/seeft-admin/src/pages/shifts/index.tsx

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
スクリーンショット
![image](https://github.com/user-attachments/assets/8f8a8cd0-cd68-41b2-96a2-d85fffeb6a6c)

# テスト項目
<!-- テストしてほしい内容を記載 -->
- シフトの表示範囲が広くなっているか
- タスクが表示領域より多くなった場合、スクロール可能になってレイアウトが崩れないか
-

# 備考