### PR TITLE
ヘルプ内のURLをマニュアルスライドに変更した

### DIFF
--- a/mobile/lib/widgets/drawer.dart
+++ b/mobile/lib/widgets/drawer.dart
@@ -83,7 +83,8 @@ class ApplicationDrawer {
           leading: Icon(Icons.help),
           onTap: () async {
             var url =
-                "https://docs.google.com/document/d/1zCiz6rcrQuAXdVNg15MWCun2c2Babz0umPJxfJLD-Wg";
+            "https://docs.google.com/presentation/d/1ukPkDkkVSXWmEDY_MBOwEHPtkgm3DL64nDdLQjoTQ_0/edit#slide=id.p1";
+                //"https://docs.google.com/document/d/1zCiz6rcrQuAXdVNg15MWCun2c2Babz0umPJxfJLD-Wg";
             if (await canLaunch(url)) {
               await launch(url);
             } else {


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
[feat]操作説明・チュートリアルの作成（その1）
<!-- 対応したIssue番号を記載 -->
resolve #0
#106
# 概要
<!-- 開発内容の概要を記載 -->
SeeFT/mobile/lib/widgets/drawer.dart    
86行目
URLを変更しました。元のURLはコメントアウトしてあります。
# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
スクリーンショット
![image](https://github.com/user-attachments/assets/bc481027-986a-4c7d-8421-e72446702b93)
![image](https://github.com/user-attachments/assets/e95e032b-bfb6-4028-9980-73f81d35ae81)


# テスト項目
<!-- テストしてほしい内容を記載 -->
-ユーザー画面のヘルプを押すと指定のドライブに飛ぶかどうか。
-
-

# 備考
ブランチ名にissue番号を入れ忘れました。ごめん。