### PR TITLE
[feat]CustomAppBarを作成

### DIFF
--- a/mobile/lib/widgets/app_bar.dart
+++ b/mobile/lib/widgets/app_bar.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import 'package:seeft_mobile/theme/tokens.dart';
+
+class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
+  final String title;
+
+  const CustomAppBar({
+    Key? key,
+    required this.title,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return AppBar(
+      title: Text(title, style: TextStyle(
+        color: AppColors.textWhite,
+        fontSize: AppFontSizes.lg,
+        fontWeight: FontWeight.bold,
+      )),
+      centerTitle: false,
+      toolbarHeight: 47,
+      backgroundColor: AppColors.main,
+    );
+  }
+
+  @override
+  Size get preferredSize => Size.fromHeight(47); // AppBarの標準の高さ
+}


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #172 

# 概要
<!-- 開発内容の概要を記載 -->
sign_in_pageとlayoutで使用予定のCustomAppBarを作成しました。

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
スクリーンショット
sign_in_pageに配置してみた様子
![image](https://github.com/user-attachments/assets/f810fad2-da5a-4267-b590-a47ee9a446ac)


# テスト項目
<!-- テストしてほしい内容を記載 -->
- [ ] 正常に呼び出すことができるか
    - どこかのページで呼び出して、ScaffoldのappBarに配置する感じで確認してください。
    - 例：mobile/lib/pages/sign_in_page.dartにて、
    import 'package:seeft_mobile/widgets/app_bar.dart';でimportして、
    appBar: CustomAppBar(title: 'ログイン'),で配置

# 備考