### PR TITLE
その他ページの概形完成

### DIFF
--- a/mobile/lib/configs/importer.dart
+++ b/mobile/lib/configs/importer.dart
@@ -20,3 +20,7 @@ export 'package:seeft_mobile/widgets/shift_dialog.dart';
 export 'package:seeft_mobile/widgets/rescue_dialog.dart';
 export 'package:seeft_mobile/widgets/table.dart';
 export 'package:seeft_mobile/widgets/drawer.dart';
+
+//style
+export 'package:seeft_mobile/theme/theme.dart';
+export 'package:seeft_mobile/theme/tokens.dart';

--- a/mobile/lib/pages/etc_page.dart
+++ b/mobile/lib/pages/etc_page.dart
@@ -28,7 +28,7 @@ class _EtcPageState extends State<EtcPage>{
             {
                 'title':'通知',
                 'icon':Icons.notifications_outlined,
-                'content':() => print('通知 tapped'),
+                'content':null,
             },
             {
                 'title':'ログアウト',

--- a/mobile/lib/pages/etc_page.dart
+++ b/mobile/lib/pages/etc_page.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+import 'package:seeft_mobile/configs/importer.dart';
+import 'package:url_launcher/url_launcher.dart';
+class EtcPage extends StatefulWidget{
+    @override
+    _EtcPageState createState()=> _EtcPageState();
+}
+
+class _EtcPageState extends State<EtcPage>{
+    @override
+    Widget build(BuildContext context){
+
+        final List<Map<String, dynamic>>items=[
+            {
+                'title':'操作説明',
+                'icon':Icons.help_outline,
+                'content':() async {
+                    var url =
+                    "https://docs.google.com/presentation/d/1ukPkDkkVSXWmEDY_MBOwEHPtkgm3DL64nDdLQjoTQ_0/edit#slide=id.p1";
+                    if (await canLaunch(url)) {
+                    await launch(url);
+                    } else {
+                    final Error error = ArgumentError('Could not launch $url');
+                    throw error;
+                    }
+                },
+            },
+            {
+                'title':'通知',
+                'icon':Icons.notifications_outlined,
+                'content':() => print('通知 tapped'),
+            },
+            {
+                'title':'ログアウト',
+                'icon':Icons.logout,
+                'content': () {
+                    Navigator.pushNamedAndRemoveUntil(
+                        context, '/signin', (Route<dynamic> route) => false);
+                },
+            },
+
+        ];
+
+        return 
+        Scaffold(
+            body: Container(
+                child:Column(
+                    children: items.map((item){
+                        return Column(
+                            children:[
+                                etcContent(
+                                    item['title'],
+                                    item['icon'],
+                                    item['content'],
+                                ),
+                                Divider(),
+                            ],
+                        );
+                    }).toList()
+                )
+            )
+        );
+    }
+}
+
+Widget etcContent(String title,IconData icon,VoidCallback? content) {
+    return Container(
+        height:72,
+        child:InkWell(
+            onTap: content,
+            child: Padding(
+                padding:EdgeInsets.symmetric(horizontal:12),
+                child:Row(
+                    children:<Widget>[
+                        Icon(icon,size:24,color:Colors.black,),
+                        SizedBox(width:12),
+                        Text(
+                            title,
+                            style:TextStyle(
+                                fontSize:AppFontSizes.md,
+                                color:Colors.black
+                            ),
+                        ),
+                        Spacer(),
+                        Icon(Icons.chevron_right),
+                    ]
+                ),
+            ),
+        ),
+    );
+}

--- a/mobile/lib/widgets/drawer.dart
+++ b/mobile/lib/widgets/drawer.dart
@@ -93,6 +93,14 @@ class ApplicationDrawer {
             }
           },
         ),
+        ListTile(
+          title: Text("その他"),
+          leading: Icon(Icons.supervised_user_circle),
+          onTap: () => {
+            Navigator.pushNamedAndRemoveUntil(
+                context, '/etc_page', (Route<dynamic> route) => false)
+          },
+        ),
       ],
     ));
   }

--- a/mobile/lib/widgets/first_jump_selector.dart
+++ b/mobile/lib/widgets/first_jump_selector.dart
@@ -9,6 +9,7 @@ import 'package:seeft_mobile/pages/schedule_page.dart';
 import 'package:seeft_mobile/pages/contact_page.dart';
 import 'package:seeft_mobile/pages/wait_page.dart';
 import 'package:seeft_mobile/pages/users_page.dart';
+import 'package:seeft_mobile/pages/etc_page.dart';
 import 'package:seeft_mobile/theme/theme.dart';
 
 class FirstJumpSelector extends StatefulWidget {
@@ -78,6 +79,7 @@ class _FirstJumpSelectorState extends State<FirstJumpSelector> {
               '/contact_page': (context) => ContactPage(),
               '/wait_page': (context) => WaitPage(),
               '/users_page': (context) => UsersPage(),
+              '/etc_page':(context) => EtcPage(),
             },
           );
         } else if (snapshot.hasError) {


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #176 
#176 
# 概要
<!-- 開発内容の概要を記載 -->
その他ぺージの作成（中身だけ）
アイコン・タイトル・タップしたときの動作の3種を配列で指定する。
一時的にその他ぺージ（仮）に飛ぶボタンをdrowerに追加した。
# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- 
![image](https://github.com/user-attachments/assets/5298dbf1-1f2f-4477-9297-05fb1639d277)

スクリーンショット

# テスト項目
<!-- テストしてほしい内容を記載 -->
-その他ぺージに遷移できるか
-デザインに不備はあるか
-タップしたときに問題なく動作するか。

# 備考
現在のタップしたときの動作には
  操作説明にはgoogledriveのurl
  通知には無し（null）
  ログアウトにはログイン画面へのページ遷移
が割り当ててある
