### PR TITLE
レスキュー機能のAPI実装

### DIFF
--- a/api/env/dev.env
+++ b/api/env/dev.env
@@ -3,3 +3,4 @@ NUTMEG_DB_PASSWORD=password
 NUTMEG_DB_HOST=nutfes-seeft-db
 NUTMEG_DB_PORT=5432
 NUTMEG_DB_NAME=seeft_db
+RESCUE_GAS_URL=https://script.google.com/macros/s/AKfycbwpuZ3HInwG67z-oUQD8azmfIRY_R8OW-iH_cQ5qF4tQYF4AdvEocZbVZ12NlooVgtevA/exec

--- a/api/env/dev.env
+++ b/api/env/dev.env
@@ -3,4 +3,4 @@ NUTMEG_DB_PASSWORD=password
 NUTMEG_DB_HOST=nutfes-seeft-db
 NUTMEG_DB_PORT=5432
 NUTMEG_DB_NAME=seeft_db
-RESCUE_GAS_URL=https://script.google.com/macros/s/AKfycbwpuZ3HInwG67z-oUQD8azmfIRY_R8OW-iH_cQ5qF4tQYF4AdvEocZbVZ12NlooVgtevA/exec
+RESCUE_GAS_URL=https://script.google.com/macros/s/AKfycbw3cr0iK3B-FbbQCEZ6l_Bk_UOs2HGPHrf6EyWuETv7ZabetfRxDAoL9h5MJ2zoiq-35A/exec

--- a/api/lib/di/di.go
+++ b/api/lib/di/di.go
@@ -68,7 +68,7 @@ func InitializeServer() db.Client {
 	questionRescueController := controller.NewQuestionRescueController(questionRescueUseCase)
 	shorthandedRescueController := controller.NewShorthandedRescueController(shorthandedRescueUseCase)
 	troubleRescueController := controller.NewTroubleRescueController(troubleRescueUseCase)
-	rescueUnifiedController := controller.NewRescueUnifiedController(questionRescueUseCase, shorthandedRescueUseCase, troubleRescueUseCase, rescueUnifiedUseCase)
+	rescueUnifiedController := controller.NewRescueUnifiedController(questionRescueUseCase, shorthandedRescueUseCase, troubleRescueUseCase, rescueUnifiedUseCase, userUseCase, taskUseCase, gradeUseCase, bureauUseCase)
 
 	// router
 	router := router.NewRouter(

--- a/api/lib/internals/controller/rescue_unified_controller.go
+++ b/api/lib/internals/controller/rescue_unified_controller.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"strconv"
+	"sync"
+	"time"
 
 	"github.com/NUTFes/SeeFT/api/lib/usecase"
 	"github.com/labstack/echo/v4"
@@ -11,9 +13,9 @@ import (
 
 // 共通のリクエスト構造体
 type RescueRequest struct {
-Type    string      `json:"type"`
-UserID  int         `json:"user_id"`
-Content interface{} `json:"content"`
+	Type    string      `json:"type"`
+	UserID  int         `json:"user_id"`
+	Content interface{} `json:"content"`
 }
 
 // 各タイプ別のContent構造体
@@ -33,11 +35,27 @@ type ShorthandedContent struct {
 	Place         string `json:"place"`
 }
 
+// Content共通情報構造体
+type RescueCommonInfo struct {
+	SenderName    string
+	Grade         string
+	Bureau        string
+	StudentNumber int
+	TaskName      string
+	AnsweredAt    string
+	EditedAt      string
+	PhoneNumber   string
+}
+
 type rescueUnifiedController struct {
 	questionRescueUseCase    usecase.QuestionRescueUseCase
 	shorthandedRescueUseCase usecase.ShorthandedRescueUseCase
 	troubleRescueUseCase     usecase.TroubleRescueUseCase
 	rescueUnifiedUseCase     usecase.RescueUnifiedUseCase
+	useruse                  usecase.UserUseCase
+	taskuse                  usecase.TaskUseCase
+	gradeuse                 usecase.GradeUseCase
+	bureauuse                usecase.BureauUseCase
 }
 
 type RescueUnifiedController interface {
@@ -51,8 +69,101 @@ func NewRescueUnifiedController(
 	su usecase.ShorthandedRescueUseCase,
 	tu usecase.TroubleRescueUseCase,
 	ru usecase.RescueUnifiedUseCase,
+	useruse usecase.UserUseCase,
+	taskuse usecase.TaskUseCase,
+	gradeuse usecase.GradeUseCase,
+	bureauuse usecase.BureauUseCase,
 ) RescueUnifiedController {
-	return &rescueUnifiedController{qu, su, tu, ru}
+	return &rescueUnifiedController{qu, su, tu, ru, useruse, taskuse, gradeuse, bureauuse}
+}
+
+// Contentから共通情報を抽出する関数
+func (r *rescueUnifiedController) extractRescueCommonInfo(c echo.Context, reqType string, content interface{}, userID int) RescueCommonInfo {
+	getUserInfo := func(userID int) (string, string, string, int, string) {
+		userIDStr := strconv.Itoa(userID)
+		user, err := r.useruse.GetUserByID(c.Request().Context(), userIDStr)
+		if err != nil {
+			return "不明なユーザー", "不明", "不明", 0, "不明"
+		}
+		grade, err := r.gradeuse.GetGradeByID(c.Request().Context(), strconv.Itoa(user.GradeID))
+		if err != nil {
+			return user.Name, "不明", "不明", user.StudentNumber, user.Tel
+		}
+		bureau, err := r.bureauuse.GetBureauByID(c.Request().Context(), strconv.Itoa(user.BureauID))
+		if err != nil {
+			return user.Name, grade.Grade, "不明", user.StudentNumber, user.Tel
+		}
+
+		return user.Name, grade.Grade, bureau.Bureau, user.StudentNumber, user.Tel
+	}
+
+	getTaskName := func(taskID int) string {
+		taskIDStr := strconv.Itoa(taskID)
+		task, err := r.taskuse.GetTaskByID(c.Request().Context(), taskIDStr)
+		if err != nil {
+			return ""
+		}
+		return task.Task
+	}
+
+	loc, err := time.LoadLocation("Asia/Tokyo")
+	var now string
+	if err == nil {
+		now = time.Now().In(loc).Format("2006-01-02 15:04:05")
+	} else {
+		now = time.Now().Format("2006-01-02 15:04:05") // ロケーション取得失敗時はUTC
+	}
+	senderName, grade, bureau, studentNumber, phoneNumber := getUserInfo(userID)
+	var taskName string
+
+	switch reqType {
+	case "trouble":
+		c := content.(map[string]interface{})
+		if tidFloat, ok := c["task_id"].(float64); ok {
+			tidInt := int(tidFloat)
+			taskName = getTaskName(tidInt)
+		}
+		
+		return RescueCommonInfo{
+			SenderName:    senderName,
+			Grade:         grade,
+			Bureau:        bureau,
+			StudentNumber: studentNumber,
+			TaskName:      taskName,
+			AnsweredAt:    now,
+			EditedAt:      now,
+			PhoneNumber:   phoneNumber,
+		}
+	case "question":
+		return RescueCommonInfo{
+			SenderName:    senderName,
+			Grade:         grade,
+			Bureau:        bureau,
+			StudentNumber: studentNumber,
+			TaskName:      "",
+			AnsweredAt:    now,
+			EditedAt:      now,
+			PhoneNumber:   phoneNumber,
+		}
+	case "shorthanded":
+		c := content.(map[string]interface{})
+		if tidFloat, ok := c["task_id"].(float64); ok {
+			tidInt := int(tidFloat)
+			taskName = getTaskName(tidInt)
+		}
+		return RescueCommonInfo{
+			SenderName:    senderName,
+			Grade:         grade,
+			Bureau:        bureau,
+			StudentNumber: studentNumber,
+			TaskName:      taskName,
+			AnsweredAt:    now,
+			EditedAt:      now,
+			PhoneNumber:   phoneNumber,
+		}
+	default:
+		return RescueCommonInfo{}
+	}
 }
 
 // 統一されたレスキューリクエスト処理
@@ -68,16 +179,99 @@ func (r *rescueUnifiedController) CreateRescue(c echo.Context) error {
 	}
 	userIDStr := strconv.Itoa(req.UserID)
 
+	// ここでDB保存用データとスプシ保存用データを作成
+	commonInfo := r.extractRescueCommonInfo(c, req.Type, req.Content, req.UserID)
+	var rescueData map[string]interface{}
 	switch req.Type {
 	case "trouble":
-		return r.handleTroubleRescue(c, req, userIDStr)
+		c := req.Content.(map[string]interface{})
+		rescueData = map[string]interface{}{
+			"rescue_type": req.Type,
+			"sender_name": commonInfo.SenderName,
+			"student_number": commonInfo.StudentNumber,
+			"phone_number": commonInfo.PhoneNumber,
+			"grade": commonInfo.Grade,
+			"bureau": commonInfo.Bureau,
+			"answered_at": commonInfo.AnsweredAt,
+			"place": c["place"],
+			"task_name": commonInfo.TaskName,
+			"detail": c["detail"],
+		}
 	case "question":
-		return r.handleQuestionRescue(c, req, userIDStr)
+		c := req.Content.(map[string]interface{})
+		rescueData = map[string]interface{}{
+			"rescue_type": req.Type,
+			"sender_name": commonInfo.SenderName,
+			"student_number": commonInfo.StudentNumber,
+			"phone_number": commonInfo.PhoneNumber,
+			"grade": commonInfo.Grade,
+			"bureau": commonInfo.Bureau,
+			"answered_at": commonInfo.AnsweredAt,
+			"question": c["question"],
+		}
 	case "shorthanded":
-		return r.handleShorthandedRescue(c, req, userIDStr)
+		c := req.Content.(map[string]interface{})
+		rescueData = map[string]interface{}{
+			"rescue_type": req.Type,
+			"sender_name": commonInfo.SenderName,
+			"student_number": commonInfo.StudentNumber,
+			"phone_number": commonInfo.PhoneNumber,
+			"grade": commonInfo.Grade,
+			"bureau": commonInfo.Bureau,
+			"answered_at": commonInfo.AnsweredAt,
+			"place": c["place"],
+			"task_name": commonInfo.TaskName,
+			"missing_number": c["missing_number"],
+		}
 	default:
-		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid rescue type"})
+		rescueData = map[string]interface{}{}
 	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	var dbErr, sheetErr error
+	var createdRescue interface{}
+
+	// DB保存
+	go func() {
+		defer wg.Done()
+		switch req.Type {
+		case "trouble":
+			dbErr = r.handleTroubleRescue(c, req, userIDStr)
+		case "question":
+			dbErr = r.handleQuestionRescue(c, req, userIDStr)
+		case "shorthanded":
+			dbErr = r.handleShorthandedRescue(c, req, userIDStr)
+		default:
+			dbErr = c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid rescue type"})
+		}
+	}()
+
+	// スプシ保存
+	go func() {
+		defer wg.Done()
+		sheetErr = r.rescueUnifiedUseCase.SaveRescueToSpreadsheet(rescueData)
+	}()
+
+	wg.Wait()
+
+	if dbErr != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": dbErr.Error()})
+	}
+	if sheetErr != nil {
+		// スプシ保存失敗は警告として返す
+		return c.JSON(http.StatusOK, map[string]interface{}{
+			"message": "Rescue saved to DB, but failed to save to spreadsheet",
+			"data":    createdRescue,
+			"sheet_error": sheetErr.Error(),
+		})
+	}
+
+	return c.JSON(http.StatusCreated, map[string]interface{}{
+		"message": "Rescue saved to DB and spreadsheet successfully",
+		"data":    createdRescue,
+	})
 }
 
 func (r *rescueUnifiedController) handleTroubleRescue(c echo.Context, req RescueRequest, userIDStr string) error {

--- a/api/lib/internals/controller/rescue_unified_controller.go
+++ b/api/lib/internals/controller/rescue_unified_controller.go
@@ -1,10 +1,9 @@
 package controller
 
 import (
-	"encoding/json"
+	"fmt"
 	"net/http"
 	"strconv"
-	"sync"
 	"time"
 
 	"github.com/NUTFes/SeeFT/api/lib/usecase"
@@ -62,6 +61,7 @@ type RescueUnifiedController interface {
 	CreateRescue(echo.Context) error
 	GetAllRescues(echo.Context) error
 	GetRescuesByUserID(echo.Context) error
+	
 }
 
 func NewRescueUnifiedController(
@@ -206,6 +206,7 @@ func (r *rescueUnifiedController) CreateRescue(c echo.Context) error {
 			"grade": commonInfo.Grade,
 			"bureau": commonInfo.Bureau,
 			"answered_at": commonInfo.AnsweredAt,
+			"task_id": contentMap["task_id"],
 			"place": contentMap["place"],
 			"task_name": commonInfo.TaskName,
 			"detail": contentMap["detail"],
@@ -244,6 +245,7 @@ func (r *rescueUnifiedController) CreateRescue(c echo.Context) error {
 			"grade": commonInfo.Grade,
 			"bureau": commonInfo.Bureau,
 			"answered_at": commonInfo.AnsweredAt,
+			"task_id": contentMap["task_id"],
 			"place": contentMap["place"],
 			"task_name": commonInfo.TaskName,
 			"missing_number": contentMap["missing_number"],
@@ -252,38 +254,65 @@ func (r *rescueUnifiedController) CreateRescue(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid rescue type"})
 	}
 
-	var wg sync.WaitGroup
-	wg.Add(2)
-
-	var dbErr, sheetErr error
 	var createdRescue interface{}
+	var rescueID int
 
-	// DB保存
-	go func() {
-		defer wg.Done()
-		switch req.Type {
-		case "trouble":
-			dbErr = r.handleTroubleRescue(c, req, userIDStr)
-		case "question":
-			dbErr = r.handleQuestionRescue(c, req, userIDStr)
-		case "shorthanded":
-			dbErr = r.handleShorthandedRescue(c, req, userIDStr)
-		default:
-			dbErr = c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid rescue type"})
+	// DB保存（順次処理）
+	switch req.Type {
+	case "trouble":
+		result, err := r.troubleRescueUseCase.CreateTroubleRescue(
+			c.Request().Context(),
+			userIDStr,
+			fmt.Sprintf("%v", rescueData["task_id"]),
+			rescueData["place"].(string),
+			rescueData["detail"].(string),
+			"todo",
+		)
+		if err != nil {
+			return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		}
-	}()
-
-	// スプシ保存
-	go func() {
-		defer wg.Done()
-		sheetErr = r.rescueUnifiedUseCase.SaveRescueToSpreadsheet(rescueData)
-	}()
-
-	wg.Wait()
-
-	if dbErr != nil {
-		return c.JSON(http.StatusInternalServerError, map[string]string{"error": dbErr.Error()})
+		createdRescue = result
+		if result != nil {
+			rescueID = result.ID
+		}
+		
+	case "question":
+		result, err := r.questionRescueUseCase.CreateQuestionRescue(
+			c.Request().Context(),
+			userIDStr,
+			rescueData["question"].(string),
+			"todo",
+		)
+		if err != nil {
+			return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		}
+		createdRescue = result
+		if result != nil {
+			rescueID = result.ID
+		}
+	case "shorthanded":
+		result, err := r.shorthandedRescueUseCase.CreateShorthandedRescue(
+			c.Request().Context(),
+			userIDStr,
+			fmt.Sprintf("%v", rescueData["task_id"]),
+			fmt.Sprintf("%v", rescueData["missing_number"]),
+			rescueData["place"].(string),
+			"todo",
+		)
+		if err != nil {
+			return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		}
+		createdRescue = result
+		if result != nil {
+			rescueID = result.ID
+		}
+	default:
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid rescue type"})
 	}
+
+	// GAS（スプシ）保存
+	rescueData["rescue_id"] = rescueID
+	sheetErr := r.rescueUnifiedUseCase.SaveRescueToSpreadsheet(rescueData)
 	if sheetErr != nil {
 		// スプシ保存失敗は警告として返す
 		return c.JSON(http.StatusOK, map[string]interface{}{
@@ -296,119 +325,6 @@ func (r *rescueUnifiedController) CreateRescue(c echo.Context) error {
 	return c.JSON(http.StatusCreated, map[string]interface{}{
 		"message": "Rescue saved to DB and spreadsheet successfully",
 		"data":    createdRescue,
-	})
-}
-
-func (r *rescueUnifiedController) handleTroubleRescue(c echo.Context, req RescueRequest, userIDStr string) error {
-	// content をTroubleContentに変換
-	contentBytes, err := json.Marshal(req.Content)
-	if err != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid trouble content"})
-	}
-
-	var content TroubleContent
-	if err := json.Unmarshal(contentBytes, &content); err != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid trouble content format"})
-	}
-
-	// バリデーション
-	if content.TaskID <= 0 {
-		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid task ID"})
-	}
-	if content.Detail == "" {
-		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Detail is required"})
-	}
-
-	taskIDStr := strconv.Itoa(content.TaskID)
-	createdTroubleRescue, err := r.troubleRescueUseCase.CreateTroubleRescue(
-		c.Request().Context(),
-		userIDStr,
-		taskIDStr,
-		content.Place,
-		content.Detail,
-		"todo",
-	)
-	if err != nil {
-		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
-	}
-
-	return c.JSON(http.StatusCreated, map[string]interface{}{
-		"message": "Trouble rescue created successfully",
-		"data":    createdTroubleRescue,
-	})
-}
-
-func (r *rescueUnifiedController) handleQuestionRescue(c echo.Context, req RescueRequest, userIDStr string) error {
-	// content をQuestionContentに変換
-	contentBytes, err := json.Marshal(req.Content)
-	if err != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid question content"})
-	}
-
-	var content QuestionContent
-	if err := json.Unmarshal(contentBytes, &content); err != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid question content format"})
-	}
-
-	// バリデーション
-	if content.Question == "" {
-		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Question is required"})
-	}
-
-	createdQuestionRescue, err := r.questionRescueUseCase.CreateQuestionRescue(
-		c.Request().Context(),
-		userIDStr,
-		content.Question,
-		"todo",
-	)
-	if err != nil {
-		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
-	}
-
-	return c.JSON(http.StatusCreated, map[string]interface{}{
-		"message": "Question rescue created successfully",
-		"data":    createdQuestionRescue,
-	})
-}
-
-func (r *rescueUnifiedController) handleShorthandedRescue(c echo.Context, req RescueRequest, userIDStr string) error {
-	// content をShorthandedContentに変換
-	contentBytes, err := json.Marshal(req.Content)
-	if err != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid shorthanded content"})
-	}
-
-	var content ShorthandedContent
-	if err := json.Unmarshal(contentBytes, &content); err != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid shorthanded content format"})
-	}
-
-	// バリデーション
-	if content.TaskID <= 0 {
-		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid task ID"})
-	}
-	if content.MissingNumber <= 0 {
-		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Missing number must be greater than 0"})
-	}
-
-	taskIDStr := strconv.Itoa(content.TaskID)
-	missingNumberStr := strconv.Itoa(content.MissingNumber)
-
-	createdShorthandedRescue, err := r.shorthandedRescueUseCase.CreateShorthandedRescue(
-		c.Request().Context(),
-		userIDStr,
-		taskIDStr,
-		missingNumberStr,
-		content.Place,
-		"todo",
-	)
-	if err != nil {
-		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
-	}
-
-	return c.JSON(http.StatusCreated, map[string]interface{}{
-		"message": "Shorthanded rescue created successfully",
-		"data":    createdShorthandedRescue,
 	})
 }
 

--- a/api/lib/internals/controller/rescue_unified_controller.go
+++ b/api/lib/internals/controller/rescue_unified_controller.go
@@ -182,9 +182,22 @@ func (r *rescueUnifiedController) CreateRescue(c echo.Context) error {
 	// ここでDB保存用データとスプシ保存用データを作成
 	commonInfo := r.extractRescueCommonInfo(c, req.Type, req.Content, req.UserID)
 	var rescueData map[string]interface{}
+	contentMap, ok := req.Content.(map[string]interface{})
+	if !ok {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Contentが不正な形式です"})
+	}
 	switch req.Type {
 	case "trouble":
-		c := req.Content.(map[string]interface{})
+		// 必須キー: task_id, place, detail
+		if _, ok := contentMap["task_id"]; !ok {
+			return c.JSON(http.StatusBadRequest, map[string]string{"error": "Contentにtask_idがありません"})
+		}
+		if _, ok := contentMap["place"]; !ok {
+			return c.JSON(http.StatusBadRequest, map[string]string{"error": "Contentにplaceがありません"})
+		}
+		if _, ok := contentMap["detail"]; !ok {
+			return c.JSON(http.StatusBadRequest, map[string]string{"error": "Contentにdetailがありません"})
+		}
 		rescueData = map[string]interface{}{
 			"rescue_type": req.Type,
 			"sender_name": commonInfo.SenderName,
@@ -193,12 +206,15 @@ func (r *rescueUnifiedController) CreateRescue(c echo.Context) error {
 			"grade": commonInfo.Grade,
 			"bureau": commonInfo.Bureau,
 			"answered_at": commonInfo.AnsweredAt,
-			"place": c["place"],
+			"place": contentMap["place"],
 			"task_name": commonInfo.TaskName,
-			"detail": c["detail"],
+			"detail": contentMap["detail"],
 		}
 	case "question":
-		c := req.Content.(map[string]interface{})
+		// 必須キー: question
+		if _, ok := contentMap["question"]; !ok {
+			return c.JSON(http.StatusBadRequest, map[string]string{"error": "Contentにquestionがありません"})
+		}
 		rescueData = map[string]interface{}{
 			"rescue_type": req.Type,
 			"sender_name": commonInfo.SenderName,
@@ -207,10 +223,19 @@ func (r *rescueUnifiedController) CreateRescue(c echo.Context) error {
 			"grade": commonInfo.Grade,
 			"bureau": commonInfo.Bureau,
 			"answered_at": commonInfo.AnsweredAt,
-			"question": c["question"],
+			"question": contentMap["question"],
 		}
 	case "shorthanded":
-		c := req.Content.(map[string]interface{})
+		// 必須キー: task_id, missing_number, place
+		if _, ok := contentMap["task_id"]; !ok {
+			return c.JSON(http.StatusBadRequest, map[string]string{"error": "Contentにtask_idがありません"})
+		}
+		if _, ok := contentMap["missing_number"]; !ok {
+			return c.JSON(http.StatusBadRequest, map[string]string{"error": "Contentにmissing_numberがありません"})
+		}
+		if _, ok := contentMap["place"]; !ok {
+			return c.JSON(http.StatusBadRequest, map[string]string{"error": "Contentにplaceがありません"})
+		}
 		rescueData = map[string]interface{}{
 			"rescue_type": req.Type,
 			"sender_name": commonInfo.SenderName,
@@ -219,12 +244,12 @@ func (r *rescueUnifiedController) CreateRescue(c echo.Context) error {
 			"grade": commonInfo.Grade,
 			"bureau": commonInfo.Bureau,
 			"answered_at": commonInfo.AnsweredAt,
-			"place": c["place"],
+			"place": contentMap["place"],
 			"task_name": commonInfo.TaskName,
-			"missing_number": c["missing_number"],
+			"missing_number": contentMap["missing_number"],
 		}
 	default:
-		rescueData = map[string]interface{}{}
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid rescue type"})
 	}
 
 	var wg sync.WaitGroup

--- a/api/lib/usecase/rescue_unified_usecase.go
+++ b/api/lib/usecase/rescue_unified_usecase.go
@@ -1,8 +1,13 @@
 package usecase
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
 	"sort"
 	"strconv"
 
@@ -22,6 +27,7 @@ type rescueUnifiedUseCase struct {
 type RescueUnifiedUseCase interface {
 	GetAllRescues(context.Context) ([]entity.RescueResponse, error)
 	GetRescuesByUserID(context.Context, string) ([]entity.RescueResponse, error)
+	SaveRescueToSpreadsheet(map[string]interface{}) error
 }
 
 func NewRescueUnifiedUseCase(
@@ -261,4 +267,49 @@ func (ru *rescueUnifiedUseCase) getTaskName(c context.Context, taskID string) (s
 	}
 
 	return task, nil
+}
+
+// スプシ保存用関数（Google Sheets APIのラッパーを想定）
+func (ru *rescueUnifiedUseCase) SaveRescueToSpreadsheet(data map[string]interface{}) error {
+	// Google Sheets APIで保存処理
+	// GAS送信
+	err := ru.SendRescueToGAS(data)
+	if err != nil {
+		fmt.Println("GAS送信失敗:", err)
+		return err
+	}
+	return nil
+}
+
+// GAS送信関数
+func (ru *rescueUnifiedUseCase) SendRescueToGAS(data map[string]interface{}) error {
+	// GASのURLを環境変数から取得
+	gasURL := os.Getenv("RESCUE_GAS_URL")
+	if gasURL == "" {
+		return errors.New("GAS URLが設定されていません (RESCUE_GAS_URL)")
+	}
+
+	// JSONに変換
+	jsonData, err := json.Marshal(data)
+	if err != nil {
+		return errors.Wrap(err, "レスキューデータのJSON変換失敗")
+	}
+
+	req, err := http.NewRequest("POST", gasURL, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return errors.Wrap(err, "GASリクエスト作成失敗")
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return errors.Wrap(err, "GASへの送信失敗")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return errors.Errorf("GASが非OKステータスを返しました: %d", resp.StatusCode)
+	}
+	return nil
 }

--- a/api/lib/usecase/trouble_rescue_usecase.go
+++ b/api/lib/usecase/trouble_rescue_usecase.go
@@ -130,7 +130,6 @@ func (tu *troubleRescueUseCase) CreateTroubleRescue(c context.Context, userID st
 	if status == "" {
 		status = "todo"
 	}
-
 	// 数値チェック
 	if _, err := strconv.Atoi(userID); err != nil {
 		return nil, errors.New("invalid user ID")


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #208 

# 概要
<!-- 開発内容の概要を記載 -->
レスキュー機能のスプシ送信部分実装

# 実装ポイント

- レスキューAPIは `type`（trouble, question, shorthanded）ごとに必須項目をバリデーションし、DB保存後にGAS（スプレッドシート）へも保存します。
- DB保存後に生成されたID（rescueID）をGAS送信データ（rescueData）に含め、スプレッドシートの「対応番号」として利用します。
- GAS保存失敗時は200で警告を返し、DB保存失敗時は500エラーを返します。
- Contentの型チェックは行わず、必須キーの有無のみをチェックしています。


# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
スクリーンショット

# テスト項目
<!-- テストしてほしい内容を記載 -->
- swaggerでAPIを呼び出し、DBとスプシに記録されているか確認
```json
{
  "type": "trouble",
  "user_id": 1,
  "content": {
    "task_id": 2,
    "place": "本部前",
    "detail": "電源が落ちた"
  }
}

{
  "type": "question",
  "user_id": 2,
  "content": {
    "question": "集合時間は何時ですか？"
  }
}

{
  "type": "shorthanded",
  "user_id": 2,
  "content": {
    "task_id": 2,
    "missing_number": 2,
    "place": "体育館"
  }
}

{
  "type": "trouble",
  "user_id": 1,
  "content": {
    "task_id": 101,
    "place": "本部前"
  }
}

{
  "type": "unknown",
  "user_id": 1,
  "content": {
    "task_id": 101,
    "place": "本部前",
    "detail": "電源が落ちた"
  }
}

{
  "type": "trouble",
  "user_id": 0,
  "content": {
    "task_id": 101,
    "place": "本部前",
    "detail": "電源が落ちた"
  }
}

```

# 備考