### PR TITLE
[feat]Newバッジ表示機能追加

### DIFF
--- a/mobile/lib/pages/my_shift_page.dart
+++ b/mobile/lib/pages/my_shift_page.dart
@@ -73,10 +73,11 @@ class _MyShiftPageState extends State<MyShiftPage>
   bool isLoading = false;       // ロード中かどうかのフラグ
   Timer? _debounceTimer;        // タブとセグメントボタン切り替え時のデバウンスタイマー
   final int debounceTime = 500; // デバウンス時間を設定
+  int _latestLoadRequestId = 0; // 古い非同期ロード結果を無効化するための連番
   final deepEq = DeepCollectionEquality.unordered().equals; // シフトカードデータの比較用の関数
   
   // New表示管理用の状態変数
-  Set<String> _newCardKeys = {};        // New対象のカードキー集合
+  final Map<int, Set<String>> _newCardKeysByDay = {}; // 日付ごとのNew対象カードキー集合
   Set<String> _openedCardKeys = {};     // 既に開かれたカードキー集合（永続化）
   
   // // 天気ごとのweatherID
@@ -106,12 +107,19 @@ class _MyShiftPageState extends State<MyShiftPage>
   // ウィジェットを初期化する関数(非同期処理は直接initStateで行えないため分離)
   Future<void> _initialize() async {
     logger.i('MyShiftPage is being initialized.');
+    // ユーザIDを取得
+    _userID = await store.getUserID();
+    logger.i('User ID: $_userID');
     
-    // Hiveから開封済みカードキーを読み込み
-    final List<dynamic>? storedKeys = openedCardKeysBox.get('opened_keys');
-    if (storedKeys != null) {
-      _openedCardKeys = storedKeys.cast<String>().toSet();
-      logger.i('Loaded ${_openedCardKeys.length} opened card keys from Hive');
+    // Hiveから開封済みカードキーを読み込み（ユーザ単位）
+    final dynamic storedValue = openedCardKeysBox.get(_openedKeysStorageKey);
+    if (storedValue is List) {
+      _openedCardKeys = storedValue.whereType<String>().toSet();
+      logger.i('Loaded ${_openedCardKeys.length} opened card keys from Hive for user $_userID');
+    } else if (storedValue != null) {
+      logger.w('Unexpected type for $_openedKeysStorageKey: ${storedValue.runtimeType}. Resetting value.');
+      await openedCardKeysBox.delete(_openedKeysStorageKey);
+      _openedCardKeys = <String>{};
     }
     
     // タブのコントローラーを初期化
@@ -121,9 +129,6 @@ class _MyShiftPageState extends State<MyShiftPage>
       vsync: this
     );
     _tabController.addListener(_handleTabChange); // タブの変更を監視するリスナーを追加
-    // ユーザIDを取得
-    _userID = await store.getUserID();
-    logger.i('User ID: $_userID');
     // 初期タブのデータを初期化
     // await _loadShiftCardDataList(_userID, _selectedDayID, _selectedWeatherID);
     await _loadShiftCardDataList(_userID, _selectedDayID, 1); // 天気は初期化時に晴れ(1)で固定
@@ -156,6 +161,10 @@ class _MyShiftPageState extends State<MyShiftPage>
   // タブ(日付)が切り替わったときの処理
   void _handleTabChange() {
     final int newDayID = _tabController.index + 1; // 日付の選択状態を取得
+    // TabControllerの通知は複数回発火するため、同じ日付なら再ロードしない
+    if (newDayID == _selectedDayID) {
+      return;
+    }
     setState(() {
       _selectedDayID = newDayID;  // 選択された日付のインデックスを更新
     });
@@ -183,6 +192,7 @@ class _MyShiftPageState extends State<MyShiftPage>
   
   // 指定のユーザID、日付ID、天気IDのシフトカードデータリストをロードする関数
   Future<void> _loadShiftCardDataList(int userID, int dayID, int weatherID) async {
+    final int requestId = ++_latestLoadRequestId;
     _debounceTimer?.cancel();           // 既存のデバウンスタイマーをキャンセル
     setState(() => isLoading = true);   // ロード中フラグをtrueに設定
     
@@ -196,16 +206,32 @@ class _MyShiftPageState extends State<MyShiftPage>
     // キャッシュデータをShiftCardDataListに変換
     final ShiftCardDataList? cashedShiftCardDataList = 
       cachedData != null ? ShiftCardDataList.fromJson(cachedData) : null;
+
+    // 画面再遷移でもNewを維持するため、永続化済みのNewキーを読み込む
+    final persistedNewKeys = _loadPersistedNewKeys(dayID);
+    final persistedVisibleNewKeys = _filterAlreadyOpened(persistedNewKeys);
     
     // 表示データをキャッシュデータで更新
     setState(() {
       shiftCardDataList = cashedShiftCardDataList;
+      // 永続化データが空でも、メモリ上のNew状態は維持して不意な消し込みを防ぐ
+      if (persistedVisibleNewKeys.isNotEmpty) {
+        _newCardKeysByDay[dayID] = persistedVisibleNewKeys;
+      } else {
+        _newCardKeysByDay[dayID] = _newCardKeysByDay[dayID] ?? <String>{};
+      }
     });
     
     // デバウンス処理
     _debounceTimer = Timer(Duration(milliseconds: debounceTime), () async{ // 一定時間日付と天気が切り替わらなかった場合に実行される
+      if (!mounted || requestId != _latestLoadRequestId) {
+        return;
+      }
       // サーバーからデータを取得
       final List<dynamic>? fetchedData = await _getShiftCardDataList(userID, dayID, weatherID);
+      if (!mounted || requestId != _latestLoadRequestId) {
+        return;
+      }
       
       // キャッシュデータとフェッチデータを比較
       if (fetchedData == null || deepEq(fetchedData, cachedData)) {
@@ -216,8 +242,13 @@ class _MyShiftPageState extends State<MyShiftPage>
             showCustomErrorSnackBar(context, 'データの取得に失敗しました。'), // スナックバーでエラーメッセージを表示
           }
           : logger.w('フェッチデータが既に最新です。キャッシュを使用します。');
-        if (mounted) {
-          setState(() => isLoading = false);   // ロード中フラグをfalseに設定
+
+        // キャッシュ表示時もNew状態を再計算する（再起動時/キャッシュ再利用時の表示崩れを防止）
+        // fetched==cached の場合は、開封時以外にNewを変化させない
+        if (mounted && requestId == _latestLoadRequestId) {
+          setState(() {
+            isLoading = false;   // ロード中フラグをfalseに設定
+          });
         }
         
         // ここにレビューの処理を挟む
@@ -233,11 +264,13 @@ class _MyShiftPageState extends State<MyShiftPage>
       // New対象カードの検出
       Set<String> detectedNewKeys = {};
       if (fetchedShiftCardDataList != null) {
+        final existingNewKeys = _filterAlreadyOpened(_loadPersistedNewKeys(dayID));
         detectedNewKeys = _detectNewOrUpdatedCardKeys(
           dayID,
           cashedShiftCardDataList,
           fetchedShiftCardDataList,
         );
+        detectedNewKeys = {...existingNewKeys, ...detectedNewKeys};
         // 既に開かれたカードを除外
         detectedNewKeys = _filterAlreadyOpened(detectedNewKeys);
       }
@@ -249,13 +282,14 @@ class _MyShiftPageState extends State<MyShiftPage>
       _showReviewFormIfNeeded(fetchedShiftCardDataList, dayID);
 
       // 表示データとNew状態をフェッチデータで更新
-      if (mounted) {
+      if (mounted && requestId == _latestLoadRequestId) {
         setState(() {
           shiftCardDataList = fetchedShiftCardDataList;
-          _newCardKeys = detectedNewKeys;
+          _newCardKeysByDay[dayID] = detectedNewKeys;
           isLoading = false; // ロード中フラグをfalseに設定
         });
       }
+      _persistNewKeys(dayID, detectedNewKeys);
     });
   }
   
@@ -315,10 +349,53 @@ class _MyShiftPageState extends State<MyShiftPage>
   }
 
   // ========== New表示のためのヘルパー関数 ==========
-  
+
+  String get _openedKeysStorageKey => 'opened_keys_$_userID';
+  String _newKeysStorageKey(int dayID) => 'new_keys_${_userID}_$dayID';
+
+  String _normalizeTextForKey(String value) {
+    return value.trim();
+  }
+
+  // "8:0" / "8:00" / "08:00" の揺れをキー生成時に吸収
+  String _normalizeTimeForKey(String value) {
+    final raw = value.trim();
+    final reg = RegExp(r'^(\d{1,2}):(\d{1,2})$');
+    final m = reg.firstMatch(raw);
+    if (m == null) {
+      return raw;
+    }
+
+    final hour = int.tryParse(m.group(1) ?? '0') ?? 0;
+    final minute = int.tryParse(m.group(2) ?? '0') ?? 0;
+    final hh = hour.clamp(0, 99).toString().padLeft(2, '0');
+    final mm = minute.clamp(0, 59).toString().padLeft(2, '0');
+    return '$hh:$mm';
+  }
+
+  Set<String> _loadPersistedNewKeys(int dayID) {
+    final dynamic storedValue = openedCardKeysBox.get(_newKeysStorageKey(dayID));
+    if (storedValue is List) {
+      return storedValue.whereType<String>().toSet();
+    }
+    if (storedValue != null) {
+      logger.w('Unexpected type for ${_newKeysStorageKey(dayID)}: ${storedValue.runtimeType}. Resetting value.');
+      openedCardKeysBox.delete(_newKeysStorageKey(dayID));
+    }
+    return <String>{};
+  }
+
+  void _persistNewKeys(int dayID, Set<String> keys) {
+    openedCardKeysBox.put(_newKeysStorageKey(dayID), keys.toList());
+  }
+
   // カードの一意キーを生成（日付＋タスク名＋開始／終了＋集合場所）
   String _cardKeyFromShiftCardData(int dayID, ShiftCardData card) {
-    return '$dayID|${card.taskName}|${card.startTime}|${card.endTime}|${card.place}';
+    final taskName = _normalizeTextForKey(card.taskName);
+    final startTime = _normalizeTimeForKey(card.startTime);
+    final endTime = _normalizeTimeForKey(card.endTime);
+    final place = _normalizeTextForKey(card.place);
+    return '$dayID|$taskName|$startTime|$endTime|$place';
   }
   
   // ShiftCardDataListをMap<カードキー, ShiftCardData>に変換
@@ -574,7 +651,7 @@ class _MyShiftPageState extends State<MyShiftPage>
                   // カードキーを生成
                   final cardKey = _cardKeyFromShiftCardData(_selectedDayID, data);
                   // このカードがNewかどうかを判定
-                  final isNew = _newCardKeys.contains(cardKey);
+                  final isNew = (_newCardKeysByDay[_selectedDayID] ?? {}).contains(cardKey);
                   
                   return Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
@@ -586,11 +663,15 @@ class _MyShiftPageState extends State<MyShiftPage>
                           // トグルを開いたときの処理
                           if (mounted) {
                             setState(() {
-                              _newCardKeys.remove(cardKey);
+                              _newCardKeysByDay[_selectedDayID]?.remove(cardKey);
                             });
                           }
+                          _persistNewKeys(
+                            _selectedDayID,
+                            _newCardKeysByDay[_selectedDayID] ?? <String>{},
+                          );
                           _openedCardKeys.add(cardKey);
-                          openedCardKeysBox.put('opened_keys', _openedCardKeys.toList());
+                          openedCardKeysBox.put(_openedKeysStorageKey, _openedCardKeys.toList());
                           logger.i('Card opened and marked as read: ${data.taskName}');
                         },
                       ),

--- a/mobile/lib/pages/my_shift_page.dart
+++ b/mobile/lib/pages/my_shift_page.dart
@@ -75,6 +75,10 @@ class _MyShiftPageState extends State<MyShiftPage>
   final int debounceTime = 500; // デバウンス時間を設定
   final deepEq = DeepCollectionEquality.unordered().equals; // シフトカードデータの比較用の関数
   
+  // New表示管理用の状態変数
+  Set<String> _newCardKeys = {};        // New対象のカードキー集合
+  Set<String> _openedCardKeys = {};     // 既に開かれたカードキー集合（永続化）
+  
   // // 天気ごとのweatherID
   // final Map<int, String> _weatherOptions = {
   //   1: "晴れ",
@@ -102,6 +106,14 @@ class _MyShiftPageState extends State<MyShiftPage>
   // ウィジェットを初期化する関数(非同期処理は直接initStateで行えないため分離)
   Future<void> _initialize() async {
     logger.i('MyShiftPage is being initialized.');
+    
+    // Hiveから開封済みカードキーを読み込み
+    final List<dynamic>? storedKeys = openedCardKeysBox.get('opened_keys');
+    if (storedKeys != null) {
+      _openedCardKeys = storedKeys.cast<String>().toSet();
+      logger.i('Loaded ${_openedCardKeys.length} opened card keys from Hive');
+    }
+    
     // タブのコントローラーを初期化
     _tabController = TabController(
       length: _dayOptions.length,
@@ -204,7 +216,9 @@ class _MyShiftPageState extends State<MyShiftPage>
             showCustomErrorSnackBar(context, 'データの取得に失敗しました。'), // スナックバーでエラーメッセージを表示
           }
           : logger.w('フェッチデータが既に最新です。キャッシュを使用します。');
-        setState(() => isLoading = false);   // ロード中フラグをfalseに設定
+        if (mounted) {
+          setState(() => isLoading = false);   // ロード中フラグをfalseに設定
+        }
         
         // ここにレビューの処理を挟む
         _showReviewFormIfNeeded(cashedShiftCardDataList, dayID);
@@ -212,19 +226,36 @@ class _MyShiftPageState extends State<MyShiftPage>
         return;
       }
       // フェッチデータが新しい場合はキャッシュデータと表示データを更新
-      shiftCardBox.put('${dayID}_${weatherID}', fetchedData); // hiveのキャッシュデータをフェッチデータで更新
       
       // フェッチデータをShiftCardDataListに変換
       final ShiftCardDataList? fetchedShiftCardDataList = ShiftCardDataList.fromJson(fetchedData);
       
+      // New対象カードの検出
+      Set<String> detectedNewKeys = {};
+      if (fetchedShiftCardDataList != null) {
+        detectedNewKeys = _detectNewOrUpdatedCardKeys(
+          dayID,
+          cashedShiftCardDataList,
+          fetchedShiftCardDataList,
+        );
+        // 既に開かれたカードを除外
+        detectedNewKeys = _filterAlreadyOpened(detectedNewKeys);
+      }
+      
+      // hiveのキャッシュデータをフェッチデータで更新
+      shiftCardBox.put('${dayID}_${weatherID}', fetchedData);
+      
       // ここにレビューの処理を挟む
       _showReviewFormIfNeeded(fetchedShiftCardDataList, dayID);
 
-      // 表示データをフェッチデータで更新
-      setState(() {
-        shiftCardDataList = fetchedShiftCardDataList;
-        isLoading = false; // ロード中フラグをfalseに設定
-      });
+      // 表示データとNew状態をフェッチデータで更新
+      if (mounted) {
+        setState(() {
+          shiftCardDataList = fetchedShiftCardDataList;
+          _newCardKeys = detectedNewKeys;
+          isLoading = false; // ロード中フラグをfalseに設定
+        });
+      }
     });
   }
   
@@ -281,6 +312,88 @@ class _MyShiftPageState extends State<MyShiftPage>
         );
       }
     });
+  }
+
+  // ========== New表示のためのヘルパー関数 ==========
+  
+  // カードの一意キーを生成（日付＋タスク名＋開始／終了＋集合場所）
+  String _cardKeyFromShiftCardData(int dayID, ShiftCardData card) {
+    return '$dayID|${card.taskName}|${card.startTime}|${card.endTime}|${card.place}';
+  }
+  
+  // ShiftCardDataListをMap<カードキー, ShiftCardData>に変換
+  Map<String, ShiftCardData> _buildCardMap(
+    int dayID,
+    ShiftCardDataList? list,
+  ) {
+    final map = <String, ShiftCardData>{};
+    if (list == null) return map;
+
+    for (final card in list.data) {
+      final key = _cardKeyFromShiftCardData(dayID, card);
+      map[key] = card;
+    }
+    return map;
+  }
+  
+  // カードの変更判定（taskName / startTime / endTime / place のいずれかが変わったか）
+  bool _isCardChanged(ShiftCardData oldCard, ShiftCardData newCard) {
+    return oldCard.taskName != newCard.taskName ||
+           oldCard.startTime != newCard.startTime ||
+           oldCard.endTime != newCard.endTime ||
+           oldCard.place != newCard.place;
+  }
+  
+  // New対象カードキーの検出
+  Set<String> _detectNewOrUpdatedCardKeys(
+    int dayID,
+    ShiftCardDataList? oldList,
+    ShiftCardDataList newList,
+  ) {
+    final newKeys = <String>{};
+
+    final oldMap = _buildCardMap(dayID, oldList);
+    final newMap = _buildCardMap(dayID, newList);
+
+    // 初回（oldList == null）の場合は全カードをNewとみなす
+    if (oldList == null) {
+      newKeys.addAll(newMap.keys);
+      logger.i('Initial load: All ${newKeys.length} cards marked as new');
+      return newKeys;
+    }
+
+    // 各カードをチェック
+    for (final entry in newMap.entries) {
+      final key = entry.key;
+      final newCard = entry.value;
+      final oldCard = oldMap[key];
+
+      // 1) 前回に存在しない → 新規カード
+      if (oldCard == null) {
+        newKeys.add(key);
+        logger.i('New card detected: ${newCard.taskName}');
+        continue;
+      }
+
+      // 2) 4項目のいずれかが変わった → 変更カード
+      if (_isCardChanged(oldCard, newCard)) {
+        newKeys.add(key);
+        logger.i('Changed card detected: ${newCard.taskName}');
+      }
+    }
+    
+    logger.i('Detected ${newKeys.length} new or updated cards');
+    return newKeys;
+  }
+  
+  // 既に開かれたカードを除外
+  Set<String> _filterAlreadyOpened(Set<String> newKeys) {
+    final filtered = newKeys.where((key) => !_openedCardKeys.contains(key)).toSet();
+    final excludedCount = newKeys.length - filtered.length;
+    if (excludedCount > 0) {
+      logger.i('Filtered out $excludedCount already opened cards');
+    }
+    return filtered;
   }
 
   @override
@@ -458,10 +571,29 @@ class _MyShiftPageState extends State<MyShiftPage>
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: shiftCardDataList!.data.map((data) {
+                  // カードキーを生成
+                  final cardKey = _cardKeyFromShiftCardData(_selectedDayID, data);
+                  // このカードがNewかどうかを判定
+                  final isNew = _newCardKeys.contains(cardKey);
+                  
                   return Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      ShiftCard(data: data),
+                      ShiftCard(
+                        data: data,
+                        isNew: isNew,
+                        onOpened: () {
+                          // トグルを開いたときの処理
+                          if (mounted) {
+                            setState(() {
+                              _newCardKeys.remove(cardKey);
+                            });
+                          }
+                          _openedCardKeys.add(cardKey);
+                          openedCardKeysBox.put('opened_keys', _openedCardKeys.toList());
+                          logger.i('Card opened and marked as read: ${data.taskName}');
+                        },
+                      ),
                       const SizedBox(height: 16.0),
                     ],
                   );

--- a/mobile/lib/pages/my_shift_page.dart
+++ b/mobile/lib/pages/my_shift_page.dart
@@ -277,6 +277,10 @@ class _MyShiftPageState extends State<MyShiftPage>
       
       // hiveのキャッシュデータをフェッチデータで更新
       shiftCardBox.put('${dayID}_${weatherID}', fetchedData);
+      // 最新データに存在しない既読キーを掃除
+      if (fetchedShiftCardDataList != null) {
+        _cleanupStaleOpenedKeys(dayID, fetchedShiftCardDataList);
+      }
       
       // ここにレビューの処理を挟む
       _showReviewFormIfNeeded(fetchedShiftCardDataList, dayID);
@@ -414,11 +418,21 @@ class _MyShiftPageState extends State<MyShiftPage>
   }
   
   // カードの変更判定（taskName / startTime / endTime / place のいずれかが変わったか）
+  // _cardKeyFromShiftCardData()と同じ正規化ロジックを使用して、フォーマット違いだけの変更を除外
   bool _isCardChanged(ShiftCardData oldCard, ShiftCardData newCard) {
-    return oldCard.taskName != newCard.taskName ||
-           oldCard.startTime != newCard.startTime ||
-           oldCard.endTime != newCard.endTime ||
-           oldCard.place != newCard.place;
+    final oldTaskName = _normalizeTextForKey(oldCard.taskName);
+    final newTaskName = _normalizeTextForKey(newCard.taskName);
+    final oldStartTime = _normalizeTimeForKey(oldCard.startTime);
+    final newStartTime = _normalizeTimeForKey(newCard.startTime);
+    final oldEndTime = _normalizeTimeForKey(oldCard.endTime);
+    final newEndTime = _normalizeTimeForKey(newCard.endTime);
+    final oldPlace = _normalizeTextForKey(oldCard.place);
+    final newPlace = _normalizeTextForKey(newCard.place);
+    
+    return oldTaskName != newTaskName ||
+           oldStartTime != newStartTime ||
+           oldEndTime != newEndTime ||
+           oldPlace != newPlace;
   }
   
   // New対象カードキーの検出
@@ -471,6 +485,25 @@ class _MyShiftPageState extends State<MyShiftPage>
       logger.i('Filtered out $excludedCount already opened cards');
     }
     return filtered;
+  }
+
+  // 最新カードに存在しない既読キーを日付単位で削除
+  void _cleanupStaleOpenedKeys(int dayID, ShiftCardDataList latestList) {
+    final latestKeys = latestList.data
+        .map((card) => _cardKeyFromShiftCardData(dayID, card))
+        .toSet();
+
+    final staleKeys = _openedCardKeys
+        .where((key) => key.startsWith('$dayID|') && !latestKeys.contains(key))
+        .toList();
+
+    if (staleKeys.isEmpty) {
+      return;
+    }
+
+    _openedCardKeys.removeAll(staleKeys);
+    openedCardKeysBox.put(_openedKeysStorageKey, _openedCardKeys.toList());
+    logger.i('Cleaned ${staleKeys.length} stale opened keys for day $dayID');
   }
 
   @override

--- a/mobile/lib/utils/permanent_store.dart
+++ b/mobile/lib/utils/permanent_store.dart
@@ -11,6 +11,8 @@ late final Box shiftCardBox;
 late final Box rescueBox;
 // レビューで送信したタスク名を保存するためのHiveのBox
 late final Box reviewedTaskNameBox;
+// 開封済みカードキーを保存するためのHiveのBox
+late final Box openedCardKeysBox;
 
 class PermanentStore {
   static PermanentStore _instance = PermanentStore();
@@ -72,5 +74,7 @@ Future<void> initHive() async {
   rescueBox = await Hive.openBox('rescue');
   // レビュー済みのタスク名を保存するためのBoxを開く
   reviewedTaskNameBox = await Hive.openBox('reviewedTaskName');
+  // 開封済みカードキーを保存するためのBoxを開く
+  openedCardKeysBox = await Hive.openBox('openedCardKeys');
   logger.i('Hiveの初期化が完了しました。');
 }

--- a/mobile/lib/widgets/shift_card.dart
+++ b/mobile/lib/widgets/shift_card.dart
@@ -1,11 +1,19 @@
 import 'package:seeft_mobile/configs/importer.dart';
 import 'package:url_launcher/url_launcher.dart';
+import 'package:seeft_mobile/widgets/new_badge.dart';
 
 // シフトカードのウィジェット
 class ShiftCard extends StatelessWidget {
   final ShiftCardData data;
+  final bool isNew;
+  final VoidCallback? onOpened;
 
-  const ShiftCard({super.key, required this.data});
+  const ShiftCard({
+    super.key,
+    required this.data,
+    this.isNew = false,
+    this.onOpened,
+  });
   
   // リンクを開くための非同期メソッドを定義
   Future<void> _launchManualUrl(String url) async {
@@ -66,15 +74,25 @@ class ShiftCard extends StatelessWidget {
                 _manualButton(url: data.url),
               ],
             ),
-            // タスク名の表示
-            Text(
-              data.taskName.toString(),
-              style: const TextStyle(
-                fontSize: AppFontSizes.md,
-                color: AppColors.textBlack, 
-                fontWeight: FontWeight.bold
-              ),
-              textAlign: TextAlign.left,
+            // タスク名とNewバッジの表示
+            Row(
+              children: [
+                Flexible(
+                  child: Text(
+                    data.taskName.toString(),
+                    style: const TextStyle(
+                      fontSize: AppFontSizes.md,
+                      color: AppColors.textBlack, 
+                      fontWeight: FontWeight.bold
+                    ),
+                    textAlign: TextAlign.left,
+                  ),
+                ),
+                if (isNew) ...[
+                  const SizedBox(width: 8.0),
+                  const NewBadge(),
+                ],
+              ],
             ),
             const SizedBox(height: 6.0),
             const Divider(
@@ -88,6 +106,12 @@ class ShiftCard extends StatelessWidget {
                 tilePadding: EdgeInsets.zero,
                 iconColor: AppColors.textBlack, // アイコンの色を変更
                 minTileHeight: 0, // タイルの高さを最小に
+                onExpansionChanged: (expanded) {
+                  // トグルを開いたときにコールバックを呼ぶ
+                  if (expanded && isNew && onOpened != null) {
+                    onOpened!();
+                  }
+                },
                 // 集合場所の表示
                 title: Row(
                   children: [


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 未読シフトへの「New!」バッジ表示の実装

<!-- 対応したIssue番号を記載 -->
resolve #245 

# 概要
<!-- 開発内容の概要を記載 -->
ユーザーが「どのシフトカードが新規追加または更新されたか」を直感的に把握できるように、カード単位でNewバッジを表示する機能の追加。
判定対象は本人のカード情報（タスク名、開始時刻、終了時刻、集合場所）のみ。

# 画面スクリーンショット等
<img width="1170" height="2532" alt="localhost_45029_layout(iPhone 12 Pro)" src="https://github.com/user-attachments/assets/4d6d92f3-02df-4a2c-a395-4fdc371b0042" />

テスト項目
・初回表示でNewが付く
・カード開封でNewが消える
・変更なし更新でNewが増えない
・対象項目変更時のみNewが付く
・タブ切替後も既読状態が維持される

確認方法
1. ターミナルで以下を入力

```jsx
docker compose up -d
cd mobile
fvm flutter run -d web-server --web-port=45029
```

2. ブラウザでhttp://localhost:45029/layout と http://localhost:3000/shifts を開く
3. [http://localhost:3000/shifts](http://localhost:3000/shifts)の方で、左の一覧にある「タスク」を開いて、タスクの編集を行う。
4. [http://localhost:45029/layout](http://localhost:45029/layout%E3%81%A7F5) でF5 or 「更新」 or 日付変更などのボタンを押す と編集したタスクにnewバッジがつく

カードの内容が変わるたびに古いキーの削除が行われていることの確認方法
1. 上の方法でタスクを変更する。
2. http://localhost:45029/layout でf12からコンソールを開いて、上部のフィルタに Cleaned と入力
3. Cleaned X stale opened keys for day Y が出ていることを確認

# 備考


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Shift cards now display a "New" badge to highlight recently added shifts; badge clears when you open a card.

* **Performance Improvements**
  * Optimized day navigation to eliminate unnecessary shift card reloads.
  * Fixed issue where delayed background operations could overwrite current shift data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->