### PR TITLE
fix: user/session repositoryのSQLインジェクション脆弱性を修正

### DIFF
--- a/api/lib/internals/repository/abstract/abstract_repository.go
+++ b/api/lib/internals/repository/abstract/abstract_repository.go
@@ -17,17 +17,17 @@ type abstractRepository struct {
 }
 
 type Crud interface {
-	Read(context.Context, string) (*sql.Rows, error)
-	ReadByID(context.Context, string) (*sql.Row, error)
-	UpdateDB(context.Context, string) error
+	Read(context.Context, string, ...interface{}) (*sql.Rows, error)
+	ReadByID(context.Context, string, ...interface{}) (*sql.Row, error)
+	UpdateDB(context.Context, string, ...interface{}) error
 }
 
 func NewCrud(client db.Client) Crud {
 	return &abstractRepository{client}
 }
 
-func (a abstractRepository) Read(ctx context.Context, query string) (*sql.Rows, error) {
-	rows, err := a.client.DB().QueryContext(ctx, query)
+func (a abstractRepository) Read(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error) {
+	rows, err := a.client.DB().QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "cannot connect SQL")
 	}
@@ -37,16 +37,16 @@ func (a abstractRepository) Read(ctx context.Context, query string) (*sql.Rows, 
 	return rows, nil
 }
 
-func (a abstractRepository) ReadByID(ctx context.Context, query string) (*sql.Row, error) {
-	row := a.client.DB().QueryRowContext(ctx, query)
+func (a abstractRepository) ReadByID(ctx context.Context, query string, args ...interface{}) (*sql.Row, error) {
+	row := a.client.DB().QueryRowContext(ctx, query, args...)
 	if debugSQL {
 		fmt.Printf("\x1b[36m%s\n", query)
 	}
 	return row, nil
 }
 
-func (a abstractRepository) UpdateDB(ctx context.Context, query string) error {
-	_, err := a.client.DB().ExecContext(ctx, query)
+func (a abstractRepository) UpdateDB(ctx context.Context, query string, args ...interface{}) error {
+	_, err := a.client.DB().ExecContext(ctx, query, args...)
 	if err != nil {
 		return err
 	}

--- a/api/lib/internals/repository/session_repository.go
+++ b/api/lib/internals/repository/session_repository.go
@@ -29,8 +29,8 @@ func NewSessionRepository(client db.Client) SessionRepository {
 
 // 作成
 func (r *sessionRepository) Create(c context.Context, userID string, accessToken string) error {
-	query := "insert into session (user_id, access_token) values (" + userID + ", '" + accessToken + "')"
-	_, err := r.client.DB().ExecContext(c, query)
+	query := "insert into session (user_id, access_token) values ($1, $2)"
+	_, err := r.client.DB().ExecContext(c, query, userID, accessToken)
 	if err != nil {
 		return err
 	}
@@ -43,8 +43,8 @@ func (r *sessionRepository) Create(c context.Context, userID string, accessToken
 // 削除
 func (r *sessionRepository) Delete(c context.Context, accessToken string) error {
 	// access tokenで該当のsessionを削除
-	query := "delete from session where access_token = '" + accessToken + "'"
-	_, err := r.client.DB().ExecContext(c, query)
+	query := "delete from session where access_token = $1"
+	_, err := r.client.DB().ExecContext(c, query, accessToken)
 	if err != nil {
 		return err
 	}
@@ -56,8 +56,8 @@ func (r *sessionRepository) Delete(c context.Context, accessToken string) error 
 
 // アクセストークンからセッションを取得
 func (r *sessionRepository) FindSessionByAccessToken(c context.Context, accessToken string) *sql.Row {
-	query := "select * from session where access_token = '" + accessToken + "'"
-	row := r.client.DB().QueryRowContext(c, query)
+	query := "select * from session where access_token = $1"
+	row := r.client.DB().QueryRowContext(c, query, accessToken)
 	if sessionDebugSQL {
 		fmt.Printf("\x1b[36m%s\n", query)
 	}
@@ -66,8 +66,8 @@ func (r *sessionRepository) FindSessionByAccessToken(c context.Context, accessTo
 
 // user_idからsessionを削除する
 func (r *sessionRepository) DeleteByUserID(c context.Context, userID string) error {
-	query := "delete from session where user_id = " + userID
-	_, err := r.client.DB().ExecContext(c, query)
+	query := "delete from session where user_id = $1"
+	_, err := r.client.DB().ExecContext(c, query, userID)
 	if err != nil {
 		return err
 	}

--- a/api/lib/internals/repository/user_repository.go
+++ b/api/lib/internals/repository/user_repository.go
@@ -42,14 +42,14 @@ func (ur *userRepository) All(c context.Context) (*sql.Rows, error) {
 
 // 1件取得
 func (ur *userRepository) Find(c context.Context, id string) (*sql.Row, error) {
-	query := "SELECT * FROM users WHERE id = " + id
-	return ur.crud.ReadByID(c, query)
+	query := "SELECT * FROM users WHERE id = $1"
+	return ur.crud.ReadByID(c, query, id)
 }
 
 // 学籍番号から取得
 func (ur *userRepository) FindByStudentNumber(c context.Context, studentNumber string) *sql.Row {
-	query := "SELECT * FROM users WHERE student_number = " + studentNumber
-	row := ur.client.DB().QueryRowContext(c, query)
+	query := "SELECT * FROM users WHERE student_number = $1"
+	row := ur.client.DB().QueryRowContext(c, query, studentNumber)
 	if userDebugSQL {
 		fmt.Printf("\x1b[36m%s\n", query)
 	}
@@ -61,8 +61,8 @@ func (ur *userRepository) Create(c context.Context, name string, mail string, gr
 	query := `
 		INSERT INTO
 			users (name, mail, grade_id, department_id, bureau_id, role_id, student_number, tel, password)
-		VALUES ('` + name + "', '" + mail + "', " + gradeID + ", " + departmentID + ", " + bureauID + ", " + roleID + ", " + studentNumber + ", '" + tel + "', '" + password + "')"
-	return ur.crud.UpdateDB(c, query)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`
+	return ur.crud.UpdateDB(c, query, name, mail, gradeID, departmentID, bureauID, roleID, studentNumber, tel, password)
 }
 
 // 編集
@@ -71,23 +71,23 @@ func (ur *userRepository) Update(c context.Context, id string, name string, mail
 		UPDATE
 			users
 		SET
-			name = '` + name +
-		"', mail = '" + mail +
-		"', grade_id = " + gradeID +
-		", department_id = " + departmentID +
-		", bureau_id = " + bureauID +
-		", role_id = " + roleID +
-		", student_number = " + studentNumber +
-		", tel = '" + tel +
-		"', password = '" + password +
-		"' WHERE id = " + id
-	return ur.crud.UpdateDB(c, query)
+			name = $1,
+			mail = $2,
+			grade_id = $3,
+			department_id = $4,
+			bureau_id = $5,
+			role_id = $6,
+			student_number = $7,
+			tel = $8,
+			password = $9
+		WHERE id = $10`
+	return ur.crud.UpdateDB(c, query, name, mail, gradeID, departmentID, bureauID, roleID, studentNumber, tel, password, id)
 }
 
 // 削除
 func (ur *userRepository) Delete(c context.Context, id string) error {
-	query := "DELETE FROM users WHERE id = " + id
-	return ur.crud.UpdateDB(c, query)
+	query := "DELETE FROM users WHERE id = $1"
+	return ur.crud.UpdateDB(c, query, id)
 }
 
 func (ur *userRepository) FindNewRecord(c context.Context) (*sql.Row, error) {
@@ -97,8 +97,8 @@ func (ur *userRepository) FindNewRecord(c context.Context) (*sql.Row, error) {
 
 // ユーザ名からユーザを取得する
 func (b *userRepository) FindByName(c context.Context, name string) (*sql.Row, error) {
-	query := "SELECT * FROM users WHERE name = '" + name + "'"
-	return b.client.DB().QueryRowContext(c, query), nil
+	query := "SELECT * FROM users WHERE name = $1"
+	return b.client.DB().QueryRowContext(c, query, name), nil
 }
 
 // 複数のユーザー名から一括でユーザーを取得する（N+1問題対策）


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
  # 対応Issue                                                                                                                  
  <!-- 対応Issue番号を記載 -->                                                               
  緊急のためなし                                                                 
                                                                                                                               
  # 概要                                 
  <!-- 開発内容の概要を記載 -->                                                                                                
  ## SQLインジェクション脆弱性の修正（user/session repository）                              
                                                                                                                               
  repository層が文字列連結でSQL文を組み立てており、認証なしで以下が成立する状態だった：
  - `DELETE /users?id=1 OR 1=1` → users テーブル全件削除                                                                       
  - `GET /users/0 OR 1=1` → 任意ユーザーの password ハッシュ、電話番号漏洩                                                               
                                                                                                                               
  ローカル環境でPoCで再現確認済みのため、最も攻撃価値の高い user/session repository をプレースホルダ化し、SQLiを根本遮断。     
                                                                                                                               
  ## 実装内容                                                                                                                  
                                                                                             
  ### `api/lib/internals/repository/abstract/abstract_repository.go`                                                           
  - `Crud` インターフェースの3メソッド（`Read` / `ReadByID` / `UpdateDB`）に可変長引数 `...interface{}` を追加
  - 各実装で `QueryContext` / `ExecContext` に args をスプレッドして素通し                                                     
  - **既存の args ゼロ呼び出しは後方互換でそのまま動作**（コンパイル通る = 既存呼び出し全箇所で破壊なし）                      
                                                                                                                               
  ### `api/lib/internals/repository/user_repository.go`                                                                        
  - 文字列連結 → `$1, $2 ...` プレースホルダに置換                                                                             
  - 対象6関数：`Find` / `FindByStudentNumber` / `Create` / `Update` / `Delete` / `FindByName`                                  
  - 対象外：`All` / `FindNewRecord`（入力なし）、`FindByNames`（既に `pq.Array` で安全）                                       
                                                                                                                               
  ### `api/lib/internals/repository/session_repository.go`                                                                     
  - 4関数すべてプレースホルダ化：`Create` / `Delete` / `FindSessionByAccessToken` / `DeleteByUserID`                           
                                                                                                                               
  # 画面スクリーンショット等             
  <!-- URLとともに貼る（なければ空欄でよい） -->                                                                               
  バックエンドAPI修正のためUIスクリーンショットなし。                                                                          
                                         
  # テスト項目                                                                                                                 
  <!-- テストしてほしい内容を記載 -->                                                                                          
  ローカル環境（`make up-api`）で動作確認済み。レビュー時の再現手順：
                                                                                                                               
  ## 1. 正常系（API が壊れていないこと）                                                     
  ```bash                                                                                                                      
  curl -s 'http://localhost:1234/users/1' | jq .                                             
  → id=1 のユーザー情報がJSONで返る ✅                                                                                         
                                                                                             
  2. SQLi 攻撃が遮断されること                                                                                                 
                                                                                                                               
  curl -s 'http://localhost:1234/users/0%20OR%201=1'
  → 500 Internal Server Error（修正前は他人のレコードが漏洩） ✅                                                               
                                                                                                                               
  curl -X DELETE 'http://localhost:1234/users?id=1%20OR%201=1'
  docker exec nutfes-seeft-db psql -U seeft -d seeft_db -c 'SELECT COUNT(*) FROM users;'                                       
  → 500エラーが返り、users 件数は 3件のまま維持 される（修正前は全件削除） ✅                                                  
                                                                                                                               
  3. ビルド確認                                                                                                                
                                                                                                                               
  docker compose exec -T api go build ./...                                                  
  → エラーなし ✅                                                                                                              
                            
```
                                                                 
  備考                                   

  本PRのスコープ外（別PRで対応予定）                                                                                           
   
  セキュリティ修正PRに複数目的を混ぜるのを避けるため、以下は意図的に本PRに含めていません：                                     
                                                                                             
  - 他 repository（task / shift / review / bureau / place / grade / department / time）の SQLi 対策                            
  - crud 経由統一（client.DB() 直接呼び出しの段階的廃止）                                    
  - 認証ミドルウェア導入（現状は誰でも全エンドポイント叩ける）                                                                 
  - password フィールドのレスポンス除外（APIレスポンスにハッシュが含まれる仕様）                                               
  - 500 → 400 のエラーコード適正化（controller層で strconv.Atoi 等）                                                           
                                                                                                                               
  実装上の補足                                                                                                                 
                                                                                                                               
  - 500エラーが返るのは、PostgreSQL が $1 の値（"0 OR 1=1" 等の文字列）を id 列の型 INTEGER                                    
  にキャストしようとして失敗するため。SQL構文として解釈されないので、データ漏洩・改ざんは発生しない。
  - any キーワードを使わなかった理由：go.mod が Go 1.16 指定のためコンパイルエラーになる。interface{} で機能的に等価。Go       
  バージョン更新は別PRの範疇と判断。                                                                                           
  - DEBUG_SQL ログには $1                
  等のテンプレートのみ出力されるようになり、意図せぬ副次的セキュリティ向上（ログから値が漏れにくい）も発生。 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of database query execution for user and session data operations through enhanced parameter handling mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->