### PR TITLE
fix: sized_box_for_whitespace を解消 (Container→SizedBox) #297

### DIFF
--- a/mobile/lib/pages/manual_list_page.dart
+++ b/mobile/lib/pages/manual_list_page.dart
@@ -45,7 +45,7 @@ class _ManualListPageState extends State<ManualListPage> {
                   child: ListView.builder(
                     itemCount: manualLength,
                     itemBuilder: (BuildContext context, int index) {
-                      return Container(
+                      return SizedBox(
                         height: 40,
                         child: _manualItem(snapshot.data, index, context));
                     },

--- a/mobile/lib/pages/users_page.dart
+++ b/mobile/lib/pages/users_page.dart
@@ -80,7 +80,7 @@ class _UsersPageState extends State<UsersPage> {
                     itemCount: usersLength,
                     itemBuilder: (BuildContext context, int index) {
                       if (userList[index]["bureauID"] == isSelectedValue) {
-                        return Container(
+                        return SizedBox(
                             height: 40,
                             child: _manualItem(snapshot.data, index, context));
                       } else {
@@ -140,7 +140,7 @@ class _UsersPageState extends State<UsersPage> {
       context: context,
       builder: (BuildContext context) => new AlertDialog(
         title: new Text('ユーザ情報'),
-        content: new Container(
+        content: new SizedBox(
           height: 200,
           width: 300,
           child: ListView(children: <Widget>[

--- a/mobile/lib/widgets/shift_dialog.dart
+++ b/mobile/lib/widgets/shift_dialog.dart
@@ -107,7 +107,7 @@ openShiftDialog(
       return SimpleDialog(
         contentPadding: EdgeInsets.zero,
         titlePadding: EdgeInsets.zero,
-        title: Container(
+        title: SizedBox(
           height: 550,
           child: Scaffold(
             appBar: AppBar(


### PR DESCRIPTION
## 概要

flutter_lints の `sized_box_for_whitespace` 違反4件を解消します（親 #286 / 子 #297）。

`sized_box_for_whitespace` の違反内容は[リンク先](https://dart.dev/tools/linter-rules/sized_box_for_whitespace)にかいてあります。
ContainerはSizedBoxよりも重いウィジェットであり、おまけにSizedBoxにはconstコンストラクタという機能があるので、SizedBoxに置き換えましょう、という警告を解消しました。

## 変更内容

余白・サイズ指定のみに使われていた `Container` を `SizedBox` に置換しました。`fvm dart fix --apply --code=sized_box_for_whitespace` による機械修正で、装飾系プロパティ（`decoration` / `color` 等）を持たない箇所のみが対象です。挙動の変更はありません。

```text
mobile/lib/pages/manual_list_page.dart  1件
mobile/lib/pages/users_page.dart        2件
mobile/lib/widgets/shift_dialog.dart    1件
```

## 確認

```bash
cd mobile
fvm flutter pub get

```

```bash
fvm flutter analyze 2>&1 | grep "sized_box_for_whitespace" | tee /dev/stderr | wc -l | xargs -I{} sh -c 'if [ "{}" = "0" ]; then echo "OK: sized_box_for_whitespace 0件"; else echo "NG: {}件残っています"; fi'

```

`sized_box_for_whitespace` が0件になることを確認済み。

Closes #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * リスト表示やダイアログのレイアウトウィジェットを最適化しました。これにより、アプリのパフォーマンスが向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->