### PR TITLE
fix: depend_on_referenced_packages を解消 #310

### DIFF
--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -36,6 +36,11 @@ dependencies:
   url_launcher: ^6.3.1
   hive_flutter: ^1.1.0
 
+  # main.dart / 各ページが直接 import するため依存に明示 (depend_on_referenced_packages)
+  flutter_web_plugins:
+    sdk: flutter
+  collection: ^1.19.0
+
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
## 概要

flutter_lints の `depend_on_referenced_packages` 違反3件を解消します（親 #286 / 子 #310）。
depend_on_referenced_packages の違反内容は[リンク先](https://dart.dev/tools/linter-rules/depend_on_referenced_packages)にかいてあります。
要約すると、実際にコードで使っているのに pubspec.yamlに書いていないパッケージがある、という警告です。s

## 変更内容

直接 import しているのに `pubspec.yaml` に依存宣言が無かった2パッケージを明示しました。宣言が無いと「別パッケージが間接的に引いているから今は動く」状態で、上流依存が変わると壊れます。

- `flutter_web_plugins` — `lib/main.dart` が `setUrlStrategy(PathUrlStrategy())` で使用。Flutter SDK 同梱パッケージのため `sdk: flutter` で宣言。
- `collection` — 2ファイルが使用。解決済みバージョン `^1.19.0` で固定。

```text
lib/main.dart:2                                                  flutter_web_plugins
lib/pages/my_shift_page.dart:3                                   collection
lib/pages/rescue/rescue_response_tab/rescue_response_tab.dart:7  collection
```

`pubspec.lock` は `mobile/.gitignore` で除外されているため差分には含まれません。

## 確認

```bash
cd mobile
fvm flutter pub get

```


```bash
fvm flutter analyze 2>&1 | grep "depend_on_referenced_packages" | tee /dev/stderr | wc -l | xargs -I{} sh -c 'if [ "{}" = "0" ]; then echo "OK: depend_on_referenced_packages 0件"; else echo "NG: {}件残っています"; fi'

```

`pub get` 成功、`depend_on_referenced_packages` が0件になることを確認済み。

Closes #310

🤖 Generated with [Claude Code](https://claude.com/claude-code)
