### PR TITLE
fix: use_super_parameters を解消 #290

### DIFF
--- a/mobile/lib/models/rescue.dart
+++ b/mobile/lib/models/rescue.dart
@@ -77,19 +77,14 @@ class TroubleRescueResponse extends RescueResponse {
   final TroubleContent content;
 
   TroubleRescueResponse({
-    required int id,
-    required String userName,
-    required String time,
-    required String status,
-    required String response,
+    required super.id,
+    required super.userName,
+    required super.time,
+    required super.status,
+    required super.response,
     required this.content,
   }) : super(
           type: 'trouble',
-          id: id,
-          userName: userName,
-          time: time,
-          status: status,
-          response: response,
         );
 
   // factory TroubleRescueResponse.fromJson(Map<String, dynamic> json) {
@@ -139,19 +134,14 @@ class QuestionRescueResponse extends RescueResponse {
   final QuestionContent content;
 
   QuestionRescueResponse({
-    required int id,
-    required String userName,
-    required String time,
-    required String status,
-    required String response,
+    required super.id,
+    required super.userName,
+    required super.time,
+    required super.status,
+    required super.response,
     required this.content,
   }) : super(
           type: 'question',
-          id: id,
-          userName: userName,
-          time: time,
-          status: status,
-          response: response,
         );
 
   // factory QuestionRescueResponse.fromJson(Map<String, dynamic> json) {
@@ -210,19 +200,14 @@ class ShorthandedRescueResponse extends RescueResponse {
   final ShorthandedContent content;
 
   ShorthandedRescueResponse({
-    required int id,
-    required String userName,
-    required String time,
-    required String status,
-    required String response,
+    required super.id,
+    required super.userName,
+    required super.time,
+    required super.status,
+    required super.response,
     required this.content,
   }) : super(
           type: 'shorthanded',
-          id: id,
-          userName: userName,
-          time: time,
-          status: status,
-          response: response,
         );
 
   // factory ShorthandedRescueResponse.fromJson(Map<String, dynamic> json) {

--- a/mobile/lib/pages/etc_page.dart
+++ b/mobile/lib/pages/etc_page.dart
@@ -5,8 +5,8 @@ import 'package:url_launcher/url_launcher.dart';
 class EtcPage extends StatelessWidget {
 
   EtcPage({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
   
   // 環境変数からSeeFTの操作説明と全体シフトのURLを取得
   final String seeftInstructionsUrl = constant.seeftInstructionsUrl;

--- a/mobile/lib/pages/rescue/rescue_page.dart
+++ b/mobile/lib/pages/rescue/rescue_page.dart
@@ -3,7 +3,7 @@ import 'package:seeft_mobile/pages/rescue/rescue_request_tab/rescue_request_tab.
 import 'package:seeft_mobile/pages/rescue/rescue_response_tab/rescue_response_tab.dart';
 
 class RescuePage extends StatefulWidget {
-  const RescuePage({Key? key}) : super(key: key);
+  const RescuePage({super.key});
   
   @override
   _RescuePageState createState() => _RescuePageState();

--- a/mobile/lib/pages/rescue/rescue_request_tab/tab_pages/question.dart
+++ b/mobile/lib/pages/rescue/rescue_request_tab/tab_pages/question.dart
@@ -8,8 +8,8 @@ import 'package:seeft_mobile/widgets/custom_error_snack_bar.dart';
 
 class RescueRequestTabQuestionPage extends StatelessWidget {
   RescueRequestTabQuestionPage({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
   
   // レスキューを送信する関数
   Future<bool> _sendRescueRequest(

--- a/mobile/lib/pages/rescue/rescue_request_tab/tab_pages/select_type.dart
+++ b/mobile/lib/pages/rescue/rescue_request_tab/tab_pages/select_type.dart
@@ -8,8 +8,8 @@ import 'package:seeft_mobile/pages/rescue/rescue_request_tab/tab_pages/question.
 class RescueRequestTabSelectTypePage extends StatelessWidget {
 
   RescueRequestTabSelectTypePage({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   // 問題の種類のリスト
   final List<Map<String, dynamic>> _listItems = [

--- a/mobile/lib/pages/rescue/rescue_request_tab/tab_pages/shorthanded.dart
+++ b/mobile/lib/pages/rescue/rescue_request_tab/tab_pages/shorthanded.dart
@@ -10,8 +10,8 @@ import 'package:seeft_mobile/widgets/custom_error_snack_bar.dart';
 
 class RescueRequestTabShorthandedPage extends StatelessWidget {
   RescueRequestTabShorthandedPage({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
   
   // ユーザIDに紐づくタスクを取得する関数
   Future<List<RescueTaskDropdownMenuItem>?> fetchData() async {

--- a/mobile/lib/pages/rescue/rescue_request_tab/tab_pages/trouble.dart
+++ b/mobile/lib/pages/rescue/rescue_request_tab/tab_pages/trouble.dart
@@ -10,8 +10,8 @@ import 'package:seeft_mobile/widgets/custom_error_snack_bar.dart';
 
 class RescueRequestTabTroublePage extends StatelessWidget {
   RescueRequestTabTroublePage({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
   
   // ユーザIDに紐づくタスクを取得する関数
   Future<List<RescueTaskDropdownMenuItem>?> fetchData() async {

--- a/mobile/lib/pages/rescue/rescue_response_tab/rescue_response_tab.dart
+++ b/mobile/lib/pages/rescue/rescue_response_tab/rescue_response_tab.dart
@@ -58,7 +58,7 @@ List<dynamic>? _getCashedRescueResponses(int? userID) {
 }
 
 class RescueResponseTab extends StatefulWidget {
-  const RescueResponseTab({Key? key}) : super(key: key);
+  const RescueResponseTab({super.key});
 
   @override
   _RescueResponseTabState createState() => _RescueResponseTabState();

--- a/mobile/lib/widgets/app_bar.dart
+++ b/mobile/lib/widgets/app_bar.dart
@@ -5,9 +5,9 @@ class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
   final String title;
 
   const CustomAppBar({
-    Key? key,
+    super.key,
     required this.title,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/mobile/lib/widgets/layout.dart
+++ b/mobile/lib/widgets/layout.dart
@@ -8,7 +8,7 @@ import 'package:seeft_mobile/pages/etc_page.dart';
 import 'package:seeft_mobile/pages/rescue/rescue_page.dart';
 
 class Layout extends StatefulWidget {
-  const Layout({Key? key}) : super(key: key);
+  const Layout({super.key});
 
   @override
   State<Layout> createState() => _LayoutState();

--- a/mobile/lib/widgets/review_bottom_sheet.dart
+++ b/mobile/lib/widgets/review_bottom_sheet.dart
@@ -40,7 +40,7 @@ class ReviewForm extends StatefulWidget {
   final String taskName;
   final int userID;
 
-  const ReviewForm({Key? key, required this.taskName, required this.userID}) : super(key: key);
+  const ReviewForm({super.key, required this.taskName, required this.userID});
 
   @override
   State<ReviewForm> createState() => _ReviewFormState();


### PR DESCRIPTION
## 概要

flutter_lints の `use_super_parameters` 違反13件を解消します（親 #286 / 子 #290）。

`use_super_parameters` は、親コンストラクタにそのまま渡すだけのパラメータを `super.パラメータ名` という省略記法で書けるにもかかわらず、冗長な形で書いている箇所を指摘するルールです（Dart 2.17 以降）。

```dart
// Before
const MyWidget({Key? key}) : super(key: key);

// After
const MyWidget({super.key});
```

## 変更内容

`fvm dart fix --apply --code=use_super_parameters` による機械修正です。挙動の変更はありません。

```text
mobile/lib/models/rescue.dart                                              複数件
mobile/lib/pages/etc_page.dart                                             1件
mobile/lib/pages/rescue/rescue_page.dart                                   1件
mobile/lib/pages/rescue/rescue_request_tab/tab_pages/question.dart         1件
mobile/lib/pages/rescue/rescue_request_tab/tab_pages/select_type.dart      1件
mobile/lib/pages/rescue/rescue_request_tab/tab_pages/shorthanded.dart      1件
mobile/lib/pages/rescue/rescue_request_tab/tab_pages/trouble.dart          1件
mobile/lib/pages/rescue/rescue_response_tab/rescue_response_tab.dart       1件
mobile/lib/widgets/app_bar.dart                                            1件
mobile/lib/widgets/layout.dart                                             1件
mobile/lib/widgets/review_bottom_sheet.dart                                1件
```

## 確認

```bash
cd mobile && fvm flutter analyze 2>&1 | grep "use_super_parameters" | tee /dev/stderr | wc -l | xargs -I{} sh -c 'if [ "{}" = "0" ]; then echo "OK: use_super_parameters 0件"; else echo "NG: {}件残っています"; fi'
```

`use_super_parameters` が0件になることを確認済み。

Closes #290

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **リファクタリング**
  * Dart言語の最新構文に対応するため、複数のウィジェットとコンポーネントのコンストラクタを最適化しました。これにより、コードの保守性と一貫性が向上し、将来的な開発効率の改善につながります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->