### PR TITLE
fix: ローカル変数の不要な先頭アンダースコアを除去 #287

### DIFF
--- a/mobile/lib/pages/etc_page.dart
+++ b/mobile/lib/pages/etc_page.dart
@@ -15,7 +15,7 @@ class EtcPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     // 項目リスト
-    final List<Map<String, dynamic>> _listItems = [
+    final List<Map<String, dynamic>> listItems = [
       {
         'text': '操作説明', 
         'explanation': 'SeeFTの操作説明を開きます',
@@ -73,17 +73,17 @@ class EtcPage extends StatelessWidget {
             children: [
               // 問題の種類を選択するリスト
               ListView.separated(
-                itemCount: _listItems.length,
+                itemCount: listItems.length,
                 shrinkWrap: true, // リストの高さを自動調整
                 physics: NeverScrollableScrollPhysics(), // スクロールを無効化
                 itemBuilder: (context, index) {
                   return ListTile(
                     leading: Icon(
-                      _listItems[index]['icon'],
+                      listItems[index]['icon'],
                       color: AppColors.main,
                     ),
                     title: Text(
-                      _listItems[index]['text'],
+                      listItems[index]['text'],
                       style: TextStyle(
                         fontSize: AppFontSizes.md,
                         fontWeight: FontWeight.bold,
@@ -91,7 +91,7 @@ class EtcPage extends StatelessWidget {
                       ),
                     ),
                     subtitle: Text(
-                      _listItems[index]['explanation'],
+                      listItems[index]['explanation'],
                       style: TextStyle(
                         fontSize: AppFontSizes.sm,
                         color: AppColors.grayDark,
@@ -104,7 +104,7 @@ class EtcPage extends StatelessWidget {
                     ),
                     onTap: () {
                       // 問題の種類が選択されたときの処理
-                      _listItems[index]['onTap']();
+                      listItems[index]['onTap']();
                     },
                   );
                 },

--- a/mobile/lib/pages/my_shift_page.dart
+++ b/mobile/lib/pages/my_shift_page.dart
@@ -327,8 +327,8 @@ class _MyShiftPageState extends State<MyShiftPage>
     // 各シフトカードに対するレビュー処理
     shiftCardDataList.data.forEach((shiftCard) {
       // シフトカードのタスクが既にレビュー済みかどうかを確認
-      final _isReviewed = reviewedTaskNameBox.get(shiftCard.taskName, defaultValue: false) == true;
-      if(_isReviewed){
+      final isReviewed = reviewedTaskNameBox.get(shiftCard.taskName, defaultValue: false) == true;
+      if(isReviewed){
         print("タスク「${shiftCard.taskName}」は既にレビュー済みです. レビューを表示しません。");
         return;
       }
@@ -340,8 +340,8 @@ class _MyShiftPageState extends State<MyShiftPage>
       print("現在時刻: $now, シフト終了時刻: $shiftEndTime");
       
       // 対象のタスクが終了しているかどうかを判定
-      final _isFinished = now.isAfter(shiftEndTime);
-      if (_isFinished) {
+      final isFinished = now.isAfter(shiftEndTime);
+      if (isFinished) {
         // 各シフトカードに対するレビュー処理を実行
         ReviewBottomSheet.show(
           context,

--- a/mobile/lib/pages/rescue/rescue_request_tab/tab_pages/question.dart
+++ b/mobile/lib/pages/rescue/rescue_request_tab/tab_pages/question.dart
@@ -44,9 +44,9 @@ class RescueRequestTabQuestionPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     // 質問内容を格納する変数
-    String _question = '';
+    String question = '';
     // 送信中かどうかを示す変数
-    bool _isSending = false;
+    bool isSending = false;
 
     return Column(
       spacing: 8.0,  // 子要素間のスペース
@@ -89,7 +89,7 @@ class RescueRequestTabQuestionPage extends StatelessWidget {
                         onChanged: (String value) {
                           // 入力されたときの処理
                           setState(() {
-                            _question = value;
+                            question = value;
                           });
                           logger.i("入力された場所: $value");
                         },
@@ -109,15 +109,15 @@ class RescueRequestTabQuestionPage extends StatelessWidget {
         StatefulBuilder(
           builder: (context, setState) {
             return CustomElevatedButton(
-              isDisabled: _isSending,
+              isDisabled: isSending,
               onPressed: () async {
                 setState(() {
-                  _isSending = true;
+                  isSending = true;
                 });
                 // レスキューを送信する
                 final isSuccess = await _sendRescueRequest(
                   context,
-                  _question,
+                  question,
                 );
                 logger.i("レスキューを送信しました");
                 if(isSuccess){
@@ -125,11 +125,11 @@ class RescueRequestTabQuestionPage extends StatelessWidget {
                   Navigator.of(context).popUntil((route) => route.isFirst);
                 }else{
                   setState(() {
-                    _isSending = false;
+                    isSending = false;
                   });
                 }
               },
-              label: _isSending ? "送信中..." : "送信",
+              label: isSending ? "送信中..." : "送信",
             );
           }
         ),

--- a/mobile/lib/pages/rescue/rescue_request_tab/tab_pages/shorthanded.dart
+++ b/mobile/lib/pages/rescue/rescue_request_tab/tab_pages/shorthanded.dart
@@ -106,16 +106,16 @@ class RescueRequestTabShorthandedPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     // 選択されたタスクを格納する変数
-    RescueTaskDropdownMenuItem _selectedTask = RescueTaskDropdownMenuItem(
+    RescueTaskDropdownMenuItem selectedTask = RescueTaskDropdownMenuItem(
       id: 0,
       taskName: 'タスクを選択してください'
     );
     // 不足人数を格納する変数
-    int _missingNumber = 0;
+    int missingNumber = 0;
     // 発生場所を格納する変数
-    String _place = '';
+    String place = '';
     // 送信中かどうかを示す変数
-    bool _isSubmitting = false;
+    bool isSubmitting = false;
 
     return FutureBuilder<List<dynamic>?>(
       future: fetchData(),
@@ -257,13 +257,13 @@ class RescueRequestTabShorthandedPage extends StatelessWidget {
                         StatefulBuilder(
                           builder: (context, setState) {
                             return CustomDropdownButton<String>(
-                              value: _selectedTask.id.toString(),
+                              value: selectedTask.id.toString(),
                               items: dropdownMenuItems,
                               isDense: true, // 高さをコンパクトにする
                               onChanged: (value) {
                                 setState(() {
                                   // 選択されたタスクを更新
-                                  _selectedTask = tasks.firstWhere(
+                                  selectedTask = tasks.firstWhere(
                                     (task) => task.id.toString() == value,
                                     orElse: () => RescueTaskDropdownMenuItem(
                                       id: 0, // タスク外
@@ -271,7 +271,7 @@ class RescueRequestTabShorthandedPage extends StatelessWidget {
                                     ),
                                   );
                                 });
-                                logger.i("選択されたタスク: ${_selectedTask.taskName}");
+                                logger.i("選択されたタスク: ${selectedTask.taskName}");
                               },
                               hintText: 'タスクを選択してください',
                             );
@@ -296,7 +296,7 @@ class RescueRequestTabShorthandedPage extends StatelessWidget {
                               onChanged: (String value) {
                                 // 入力されたときの処理
                                 setState(() {
-                                  _missingNumber = int.tryParse(value) ?? 0;
+                                  missingNumber = int.tryParse(value) ?? 0;
                                 });
                                 logger.i("入力された人数: $value");
                               },
@@ -321,7 +321,7 @@ class RescueRequestTabShorthandedPage extends StatelessWidget {
                               onChanged: (String value) {
                                 // 入力されたときの処理
                                 setState(() {
-                                  _place = value;
+                                  place = value;
                                 });
                                 logger.i("入力された場所: $value");
                               },
@@ -341,17 +341,17 @@ class RescueRequestTabShorthandedPage extends StatelessWidget {
               StatefulBuilder(
                 builder: (context, setState) {
                   return CustomElevatedButton(
-                    isDisabled: _isSubmitting,
+                    isDisabled: isSubmitting,
                     onPressed: () async {
                       setState(() {
-                        _isSubmitting = true;
+                        isSubmitting = true;
                       });
                       // レスキューを送信する
                       final isSuccess = await _sendRescueRequest(
                         context,
-                        _selectedTask,
-                        _missingNumber,
-                        _place,
+                        selectedTask,
+                        missingNumber,
+                        place,
                       );
                       logger.i("レスキューを送信しました");
                       if(isSuccess){
@@ -359,11 +359,11 @@ class RescueRequestTabShorthandedPage extends StatelessWidget {
                         Navigator.of(context).popUntil((route) => route.isFirst);
                       }else{
                         setState(() {
-                          _isSubmitting = false;
+                          isSubmitting = false;
                         });
                       }
                     },
-                    label: _isSubmitting ? "送信中..." : "送信",
+                    label: isSubmitting ? "送信中..." : "送信",
                   );
                 }
               ),

--- a/mobile/lib/pages/rescue/rescue_request_tab/tab_pages/trouble.dart
+++ b/mobile/lib/pages/rescue/rescue_request_tab/tab_pages/trouble.dart
@@ -103,16 +103,16 @@ class RescueRequestTabTroublePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     // 選択されたタスクを格納する変数
-    RescueTaskDropdownMenuItem _selectedTask = RescueTaskDropdownMenuItem(
+    RescueTaskDropdownMenuItem selectedTask = RescueTaskDropdownMenuItem(
       id: 0, // 初期値はタスク外(実際の「タスク外」のidは3だが、DropDown内でのidの重複を避けるために0としている)
       taskName: 'タスク外',
     );
     // トラブルの詳細を格納する変数
-    String _detail = '';
+    String detail = '';
     // 発生場所を格納する変数
-    String _place = '';
+    String place = '';
     // 送信中かどうかを示す変数
-    bool _isSending = false;
+    bool isSending = false;
 
     return FutureBuilder<List<dynamic>?>(
       future: fetchData(),
@@ -254,13 +254,13 @@ class RescueRequestTabTroublePage extends StatelessWidget {
                         StatefulBuilder(
                           builder: (context, setState) {
                             return CustomDropdownButton<String>(
-                              value: _selectedTask.id.toString(),
+                              value: selectedTask.id.toString(),
                               items: dropdownMenuItems,
                               isDense: true, // 高さをコンパクトにする
                               onChanged: (value) {
                                 setState(() {
                                   // 選択されたタスクを更新
-                                  _selectedTask = tasks.firstWhere(
+                                  selectedTask = tasks.firstWhere(
                                     (task) => task.id.toString() == value,
                                     orElse: () => RescueTaskDropdownMenuItem(
                                       id: 0, // タスク外
@@ -268,7 +268,7 @@ class RescueRequestTabTroublePage extends StatelessWidget {
                                     ),
                                   );
                                 });
-                                logger.i("選択されたタスク: ${_selectedTask.taskName}");
+                                logger.i("選択されたタスク: ${selectedTask.taskName}");
                               },
                               hintText: 'タスクを選択してください',
                             );
@@ -292,7 +292,7 @@ class RescueRequestTabTroublePage extends StatelessWidget {
                               onChanged: (String value) {
                                 // 入力されたときの処理
                                 setState(() {
-                                  _place = value;
+                                  place = value;
                                 });
                                 logger.i("入力された場所: $value");
                               },
@@ -317,7 +317,7 @@ class RescueRequestTabTroublePage extends StatelessWidget {
                               onChanged: (String value) {
                                 // 入力されたときの処理
                                 setState(() {
-                                  _detail = value;
+                                  detail = value;
                                 });
                                 logger.i("入力された詳細: $value");
                               },
@@ -337,17 +337,17 @@ class RescueRequestTabTroublePage extends StatelessWidget {
               StatefulBuilder(
                 builder: (context, setState) {
                   return CustomElevatedButton(
-                    isDisabled: _isSending,
+                    isDisabled: isSending,
                     onPressed: () async {
                       setState(() {
-                        _isSending = true;
+                        isSending = true;
                       });
                       // レスキューを送信する
                       final isSuccess = await _sendRescueRequest(
                         context,
-                        _selectedTask,
-                        _place,
-                        _detail
+                        selectedTask,
+                        place,
+                        detail
                       );
                       logger.i("レスキューを送信しました");
                       if(isSuccess){
@@ -355,11 +355,11 @@ class RescueRequestTabTroublePage extends StatelessWidget {
                         Navigator.of(context).popUntil((route) => route.isFirst);
                       }else{
                         setState(() {
-                          _isSending = false;
+                          isSending = false;
                         });
                       }
                     },
-                    label: _isSending ? "送信中..." : "送信",
+                    label: isSending ? "送信中..." : "送信",
                   );
                 }
               ),

--- a/mobile/lib/pages/rescue/rescue_response_tab/rescue_response_tab.dart
+++ b/mobile/lib/pages/rescue/rescue_response_tab/rescue_response_tab.dart
@@ -341,20 +341,20 @@ class _RescueResponseTabState extends State<RescueResponseTab> {
   
   // レスキューのレスポンスのステータスに応じたアイコンを表示するウィジェット
   Widget _statusIcon(String status) {
-    Color _iconColor = AppColors.error;
-    String _iconText = "未対応";
+    Color iconColor = AppColors.error;
+    String iconText = "未対応";
     switch (status) {
       case 'done':
-        _iconColor = Color(0xFF325c23);
-        _iconText = "対応済";
+        iconColor = Color(0xFF325c23);
+        iconText = "対応済";
         break;
       case 'inProgress':
-        _iconColor = Color(0xFF3A73E6);
-        _iconText = "対応中";
+        iconColor = Color(0xFF3A73E6);
+        iconText = "対応中";
         break;
       case 'todo':
-        _iconColor = AppColors.error;
-        _iconText = "未対応";
+        iconColor = AppColors.error;
+        iconText = "未対応";
         break;
     }
     
@@ -362,12 +362,12 @@ class _RescueResponseTabState extends State<RescueResponseTab> {
       padding: EdgeInsets.all(4.0),
       decoration: BoxDecoration(
         borderRadius: BorderRadius.circular(8.0),
-        border: Border.all(color: _iconColor, width: 2.0),
+        border: Border.all(color: iconColor, width: 2.0),
       ),
       child: Text(
-        _iconText,
+        iconText,
         style: TextStyle(
-          color: _iconColor,
+          color: iconColor,
           fontWeight: FontWeight.bold,
           fontSize: AppFontSizes.sm,
         ),

--- a/mobile/lib/widgets/first_jump_selector.dart
+++ b/mobile/lib/widgets/first_jump_selector.dart
@@ -16,11 +16,11 @@ class _FirstJumpSelectorState extends State<FirstJumpSelector> {
 
   Future<bool> getPrefRead() async {
     try {
-      final _isUserID = await store.isUserID();
-      final _userID = await store.getUserID();
-      logger.w(_userID);
-      logger.w(_isUserID);
-      return _isUserID;
+      final isUserID = await store.isUserID();
+      final userID = await store.getUserID();
+      logger.w(userID);
+      logger.w(isUserID);
+      return isUserID;
     } catch (e) {
       print(e);
       return false;
@@ -30,7 +30,7 @@ class _FirstJumpSelectorState extends State<FirstJumpSelector> {
   @override
   Widget build(BuildContext context) {
     logger.i('navigated Splash.');
-    final _materialTheme = MaterialTheme(Typography().black); // Typography() は変更が必要な可能性があります
+    final materialTheme = MaterialTheme(Typography().black); // Typography() は変更が必要な可能性があります
 
     return FutureBuilder(
       future: getPrefRead(),
@@ -52,8 +52,8 @@ class _FirstJumpSelectorState extends State<FirstJumpSelector> {
 
           app = new MaterialApp(
             title: constant.appName,
-            theme: _materialTheme.light(), // ライトモードのテーマ
-              darkTheme: _materialTheme.dark(), // ダークモードのテーマ
+            theme: materialTheme.light(), // ライトモードのテーマ
+              darkTheme: materialTheme.dark(), // ダークモードのテーマ
               themeMode: ThemeMode.light, // ライトモードを適用
             initialRoute: homeWidget,
             routes: {
@@ -64,8 +64,8 @@ class _FirstJumpSelectorState extends State<FirstJumpSelector> {
         } else if (snapshot.hasError) {
           app = new MaterialApp(
             title: constant.appName,
-            theme: _materialTheme.light(), // ライトモードのテーマ
-              darkTheme: _materialTheme.dark(), // ダークモードのテーマ
+            theme: materialTheme.light(), // ライトモードのテーマ
+              darkTheme: materialTheme.dark(), // ダークモードのテーマ
               themeMode: ThemeMode.light, // ライトモードを適用
             home: Scaffold(
               appBar: AppBar(

--- a/mobile/lib/widgets/rescue_dialog.dart
+++ b/mobile/lib/widgets/rescue_dialog.dart
@@ -9,21 +9,21 @@ Future<void> openRescueDialog(BuildContext context,) async {
     barrierDismissible: false, // user must tap button!
     barrierColor: Colors.black.withOpacity(0.5),
     builder: (BuildContext context) {
-      int _rescuePageIndex = 0;
-      bool _manualChecked = false;
-      bool _poepleChecked = false;
-      bool _confirmError1 = false;
+      int rescuePageIndex = 0;
+      bool manualChecked = false;
+      bool poepleChecked = false;
+      bool confirmError1 = false;
 
-      bool _taskChecked = false;
-      bool _locateChecked = false;
-      bool _contentChecked = false;
-      bool _confirmError2 = false;
-      TextEditingController _rescueContent = TextEditingController(); 
-      TextEditingController _rescueNumberofPeople = TextEditingController(); 
-      String? _rescuePostLevel;
-      String? _rescuePostLeve2;
+      bool taskChecked = false;
+      bool locateChecked = false;
+      bool contentChecked = false;
+      bool confirmError2 = false;
+      TextEditingController rescueContent = TextEditingController(); 
+      TextEditingController rescueNumberofPeople = TextEditingController(); 
+      String? rescuePostLevel;
+      String? rescuePostLeve2;
 
-      bool _isChecked = false;
+      bool isChecked = false;
 
 
       return StatefulBuilder(
@@ -31,18 +31,18 @@ Future<void> openRescueDialog(BuildContext context,) async {
           return AlertDialog(
             //各ページのタイトル
             title:Text(
-              _rescuePageIndex == 0 ? 'レスキュー要請1/2':
-              _rescuePageIndex == 1 ? 'レスキュー要請1/2':
-              _rescuePageIndex == 2 ? '最終確認':
+              rescuePageIndex == 0 ? 'レスキュー要請1/2':
+              rescuePageIndex == 1 ? 'レスキュー要請1/2':
+              rescuePageIndex == 2 ? '最終確認':
               '要請完了'
             ),
             content:SizedBox(
               height:
-              (_rescuePageIndex == 0) ? MediaQuery.of(context).size.height*0.2 :
-              (_rescuePageIndex == 1) ? MediaQuery.of(context).size.height*0.5 :
+              (rescuePageIndex == 0) ? MediaQuery.of(context).size.height*0.2 :
+              (rescuePageIndex == 1) ? MediaQuery.of(context).size.height*0.5 :
               MediaQuery.of(context).size.height*0.1,
               child:IndexedStack(
-              index:_rescuePageIndex,
+              index:rescuePageIndex,
               children:[
                 //1ページ目のcontent
                 SingleChildScrollView(
@@ -57,16 +57,16 @@ Future<void> openRescueDialog(BuildContext context,) async {
                           highlightColor:Colors.transparent,
                           onTap:(){
                                 setState((){
-                                  _manualChecked = !_manualChecked;
+                                  manualChecked = !manualChecked;
                                 });
                               },
                           child:Row(
                             children:[
                               Checkbox(
-                                value: _manualChecked,
+                                value: manualChecked,
                                 onChanged: (bool? value) {
                                   setState(() { // 🔹 `setState()` で UI を更新
-                                    _manualChecked = value!;
+                                    manualChecked = value!;
                                   });
                                 },
                               ),
@@ -82,16 +82,16 @@ Future<void> openRescueDialog(BuildContext context,) async {
                           highlightColor:Colors.transparent,
                           onTap:(){
                                 setState((){
-                                  _poepleChecked= !_poepleChecked;
+                                  poepleChecked= !poepleChecked;
                                 });
                               },
                         child:Row(
                           children:[
                             Checkbox(
-                            value: _poepleChecked,
+                            value: poepleChecked,
                             onChanged: (bool? value) {
                               setState(() { // 🔹 `setState()` で UI を更新
-                                _poepleChecked = value!;
+                                poepleChecked = value!;
                               });
                             },
                             ),
@@ -101,7 +101,7 @@ Future<void> openRescueDialog(BuildContext context,) async {
                         )
                         ),
                       ),
-                      if (_confirmError1)
+                      if (confirmError1)
                         Text('確認をしてください',style:TextStyle(color:Colors.red))
                     ]
                   )
@@ -122,7 +122,7 @@ Future<void> openRescueDialog(BuildContext context,) async {
                             }).toList();
                           },
                           onSelected: (String selecttask) {
-                            _taskChecked = !_taskChecked;
+                            taskChecked = !taskChecked;
                           },
                           fieldViewBuilder: (context, textEditingController, focusNode, onFieldSubmitted) {
                             return TextField(
@@ -136,7 +136,7 @@ Future<void> openRescueDialog(BuildContext context,) async {
                             );
                           },
                         ), 
-                        if(_taskChecked == false && _confirmError2 == true)
+                        if(taskChecked == false && confirmError2 == true)
                           Text('必要事項を入力してください',style:TextStyle(color:Colors.red)),
                         SizedBox(height: 20),
                         Text('場所', style:Theme.of(context).textTheme.titleLarge),
@@ -149,7 +149,7 @@ Future<void> openRescueDialog(BuildContext context,) async {
                             }).toList();
                           },
                           onSelected: (String selectlocate) {
-                            _locateChecked = !_locateChecked;
+                            locateChecked = !locateChecked;
                           },
                           fieldViewBuilder: (context, textEditingController, focusNode, onFieldSubmitted) {
                             return TextField(
@@ -163,12 +163,12 @@ Future<void> openRescueDialog(BuildContext context,) async {
                             );
                           }
                         ),
-                        if(_locateChecked == false && _confirmError2 == true)
+                        if(locateChecked == false && confirmError2 == true)
                           Text('必要事項を入力してください',style:TextStyle(color:Colors.red)),
                         Text('内容', style:Theme.of(context).textTheme.titleLarge),
                         Text('どんな問題が発生したのか、なるべく詳しく記入してください。'),
                         TextField(
-                          controller: _rescueContent,
+                          controller: rescueContent,
                           maxLines:null,
                           decoration:InputDecoration(
                             border: OutlineInputBorder(),
@@ -178,7 +178,7 @@ Future<void> openRescueDialog(BuildContext context,) async {
                         Text('必要人数',style:Theme.of(context).textTheme.titleLarge),
                         Text('必要な人数を入力してください(半角数字)'),
                         TextField(
-                          controller: _rescueNumberofPeople,
+                          controller: rescueNumberofPeople,
                           keyboardType: TextInputType.number,
                           inputFormatters:[FilteringTextInputFormatter.digitsOnly],
                           maxLines:1,
@@ -192,51 +192,51 @@ Future<void> openRescueDialog(BuildContext context,) async {
                         ListTile(
                           title:Text('部門長レベル'),
                           leading:Radio(
-                            groupValue: _rescuePostLevel,
+                            groupValue: rescuePostLevel,
                             value:'A',
                             onChanged:(String? value){
                               setState((){
-                                _rescuePostLevel = value;
+                                rescuePostLevel = value;
                               });
                             },
                           ),
                           onTap:(){
                             setState((){
-                              _rescuePostLevel = 'A';
+                              rescuePostLevel = 'A';
                             });
                           },
                         ),
                         ListTile(
                           title:Text('局長レベル'),
                           leading:Radio(
-                            groupValue: _rescuePostLevel,
+                            groupValue: rescuePostLevel,
                             value:'B',
                             onChanged:(String? value){
                               setState((){
-                                _rescuePostLevel = value;
+                                rescuePostLevel = value;
                               });
                             },
                           ),
                           onTap:(){
                             setState((){
-                              _rescuePostLevel = 'B';
+                              rescuePostLevel = 'B';
                             });
                           },
                         ),
                         ListTile(
                           title:Text('委員長レベル'),
                           leading:Radio(
-                            groupValue: _rescuePostLevel,
+                            groupValue: rescuePostLevel,
                             value: 'C',
                             onChanged:(String? value){
                               setState((){
-                                _rescuePostLevel = value;
+                                rescuePostLevel = value;
                               });
                             },
                           ),
                           onTap:(){
                             setState((){
-                              _rescuePostLevel = 'C';
+                              rescuePostLevel = 'C';
                             });
                           },
                         ),
@@ -245,51 +245,51 @@ Future<void> openRescueDialog(BuildContext context,) async {
                         ListTile(
                           title:Text('10分以内'),
                           leading:Radio(
-                            groupValue: _rescuePostLeve2,
+                            groupValue: rescuePostLeve2,
                             value: 'A',
                             onChanged:(String? value){
                               setState((){
-                                _rescuePostLeve2 = value;
+                                rescuePostLeve2 = value;
                               });
                             },
                           ),
                           onTap:(){
                             setState((){
-                              _rescuePostLeve2 = 'A';
+                              rescuePostLeve2 = 'A';
                             });
                           },
                         ),
                         ListTile(
                           title:Text('30分以内'),
                           leading:Radio(
-                            groupValue: _rescuePostLeve2,
+                            groupValue: rescuePostLeve2,
                             value: 'B',
                             onChanged:(String? value){
                               setState((){
-                                _rescuePostLeve2 = value;
+                                rescuePostLeve2 = value;
                               });
                             },
                           ),
                           onTap:(){
                             setState((){
-                              _rescuePostLeve2 = 'B';
+                              rescuePostLeve2 = 'B';
                             });
                           },
                         ),
                         ListTile(
                           title:Text('それ以上'),
                           leading:Radio(
-                            groupValue: _rescuePostLeve2,
+                            groupValue: rescuePostLeve2,
                             value: 'C',
                             onChanged:(String? value){
                               setState((){
-                                _rescuePostLeve2 = value;
+                                rescuePostLeve2 = value;
                               });
                             },
                           ),
                           onTap:(){
                             setState((){
-                              _rescuePostLeve2 = 'C';
+                              rescuePostLeve2 = 'C';
                             });
                           },
                         ),
@@ -315,7 +315,7 @@ Future<void> openRescueDialog(BuildContext context,) async {
             ),
             //条件分岐でactionを記述
             actions:<Widget>[
-              if(_rescuePageIndex == 0)...[
+              if(rescuePageIndex == 0)...[
                 TextButton(
                   child:
                     Text('キャンセル'),
@@ -328,24 +328,24 @@ Future<void> openRescueDialog(BuildContext context,) async {
                     Text('次へ'),
                     onPressed: () {
                       setState((){
-                        if (_manualChecked==true && _poepleChecked==true){
-                          _rescuePageIndex = 1;
-                          _confirmError1 = false;
+                        if (manualChecked==true && poepleChecked==true){
+                          rescuePageIndex = 1;
+                          confirmError1 = false;
                         }
                         else{
-                          _confirmError1 = true;
+                          confirmError1 = true;
                         }
                       });
                     }
                 )
               ]
-              else if (_rescuePageIndex == 1)...[
+              else if (rescuePageIndex == 1)...[
                 TextButton(
                   child:
                     const Text('戻る'),
                       onPressed: () {
                         setState((){
-                        _rescuePageIndex = 0;
+                        rescuePageIndex = 0;
                         });
                       }
                 ),
@@ -354,18 +354,18 @@ Future<void> openRescueDialog(BuildContext context,) async {
                     const Text('送信'),
                     onPressed: () {
                       setState((){
-                        if (_taskChecked==true && _locateChecked==true){
-                          _rescuePageIndex = 2;
-                          _confirmError2 = false;
+                        if (taskChecked==true && locateChecked==true){
+                          rescuePageIndex = 2;
+                          confirmError2 = false;
                         }
                         else{
-                          _confirmError2 = true;
+                          confirmError2 = true;
                         }
                       });
                     }
                 )
               ]
-              else if (_rescuePageIndex == 2)...[
+              else if (rescuePageIndex == 2)...[
                 TextButton(
                   child:(
                     Text('キャンセル')
@@ -386,7 +386,7 @@ Future<void> openRescueDialog(BuildContext context,) async {
                   }
                 )
               ]
-              else if (_rescuePageIndex == 3)
+              else if (rescuePageIndex == 3)
                 TextButton(
                   child:(
                     Text('閉じる')


### PR DESCRIPTION
## 概要

flutter_lints の `no_leading_underscores_for_local_identifiers` 違反31件を解消します（親 #286 / 子 #287）。

Dart では `_` で始まる識別子はファイルスコープのプライベートを意味しますが、ローカル変数はそもそも関数外から参照できないため、`_` をつけても意味が変わりません。誤解を招く記法を除去します。

```dart
// Before
final _count = 0;
var _listItems = [];

// After
final count = 0;
var listItems = [];
```

## 変更内容

`fvm dart fix --apply --code=no_leading_underscores_for_local_identifiers` による機械修正です。挙動の変更はありません。

```text
mobile/lib/pages/etc_page.dart                                              複数件
mobile/lib/pages/my_shift_page.dart                                         複数件
mobile/lib/pages/rescue/rescue_request_tab/tab_pages/question.dart          複数件
mobile/lib/pages/rescue/rescue_request_tab/tab_pages/shorthanded.dart       複数件
mobile/lib/pages/rescue/rescue_request_tab/tab_pages/trouble.dart           複数件
mobile/lib/pages/rescue/rescue_response_tab/rescue_response_tab.dart        複数件
mobile/lib/widgets/first_jump_selector.dart                                 複数件
mobile/lib/widgets/rescue_dialog.dart                                       複数件
```

## 確認

```bash
cd mobile && fvm flutter analyze 2>&1 | grep "no_leading_underscores_for_local_identifiers" | tee /dev/stderr | wc -l | xargs -I{} sh -c 'if [ "{}" = "0" ]; then echo "OK: no_leading_underscores_for_local_identifiers 0件"; else echo "NG: {}件残っています"; fi'
```

`no_leading_underscores_for_local_identifiers` が0件になることを確認済み。

Closes #287