### PR TITLE
fix: スタックトレースが効くように修正 #291

### DIFF
--- a/mobile/lib/utils/api.dart
+++ b/mobile/lib/utils/api.dart
@@ -72,7 +72,7 @@ class Api {
     } catch (err) {
       logger.e(err);
       // calling api.get みたいに呼び出し元参照できるようにしたい
-      throw err;
+      rethrow;
     }
   }
 
@@ -85,7 +85,7 @@ class Api {
     } catch (err) {
       logger.e(err);
       // calling api.get みたいに呼び出し元参照できるようにしたい
-      throw err;
+      rethrow;
     }
   }
 
@@ -99,7 +99,7 @@ class Api {
     } catch (err) {
       logger.e(err);
       // calling api.get みたいに呼び出し元参照できるようにしたい
-      throw err;
+      rethrow;
     }
   }
 
@@ -114,7 +114,7 @@ class Api {
     } catch (err) {
       logger.e(err);
       // calling api.get みたいに呼び出し元参照できるようにしたい
-      throw err;
+      rethrow;
     }
   }
 
@@ -129,7 +129,7 @@ class Api {
     } catch (err) {
       logger.e(err);
       // calling api.get みたいに呼び出し元参照できるようにしたい
-      throw err;
+      rethrow;
     }
   }
 
@@ -144,7 +144,7 @@ class Api {
     } catch (err) {
       logger.e(err);
       // calling api.get みたいに呼び出し元参照できるようにしたい
-      throw err;
+      rethrow;
     }
   }
 
@@ -159,7 +159,7 @@ class Api {
     } catch (err) {
       logger.e(err);
       // calling api.get みたいに呼び出し元参照できるようにしたい
-      throw err;
+      rethrow;
     }
   }
 
@@ -174,7 +174,7 @@ class Api {
     } catch (err) {
       logger.e(err);
       // calling api.get みたいに呼び出し元参照できるようにしたい
-      throw err;
+      rethrow;
     }
   }
 
@@ -197,7 +197,7 @@ class Api {
     } catch (err) {
       logger.e(err);
       // calling api.get みたいに呼び出し元参照できるようにしたい
-      throw err;
+      rethrow;
     }
   }
 
@@ -209,7 +209,7 @@ class Api {
     } catch (err) {
       logger.e(err);
       // calling api.get みたいに呼び出し元参照できるようにしたい
-      throw err;
+      rethrow;
     }
   }
 
@@ -221,7 +221,7 @@ class Api {
     } catch (err) {
       logger.e(err);
       // calling api.get みたいに呼び出し元参照できるようにしたい
-      throw err;
+      rethrow;
     }
   }
 
@@ -232,7 +232,7 @@ class Api {
       return await get(url);
     } catch (err) {
       logger.e(err);
-      throw err;
+      rethrow;
     }
   }
 


### PR DESCRIPTION
## 概要

flutter_lints の `use_rethrow_when_possible` 違反12件を解消します（親 #286 / 子 #291）。

`catch` で捕まえた例外を再スローする際、`throw e` では catch ブロックが新たな起点となりスタックトレースが失われます。`rethrow` を使うことで元の発生箇所からのスタックトレースが保たれ、障害調査時に正確なエラー経路が確認できます。

```dart
// Before
} catch (e) {
  throw e;
}

// After
} catch (e) {
  rethrow;
}
```

## 変更内容

`fvm dart fix --apply --code=use_rethrow_when_possible` による機械修正です。挙動の変更はありません。

```text
mobile/lib/utils/api.dart  12件
```

## 確認

```bash
cd mobile && fvm flutter analyze 2>&1 | grep "use_rethrow_when_possible" | tee /dev/stderr | wc -l | xargs -I{} sh -c 'if [ "{}" = "0" ]; then echo "OK: use_rethrow_when_possible 0件"; else echo "NG: {}件残っています"; fi'
```

`use_rethrow_when_possible` が0件になることを確認済み。

Closes #291