### PR TITLE
fix: use_key_in_widget_constructors を解消 #292

### DIFF
--- a/mobile/lib/pages/manual_list_page.dart
+++ b/mobile/lib/pages/manual_list_page.dart
@@ -7,6 +7,8 @@ import 'package:url_launcher/url_launcher.dart';
 import 'package:seeft_mobile/pages/wait_page.dart';
 
 class ManualListPage extends StatefulWidget {
+  const ManualListPage({super.key});
+
   @override
   _ManualListPageState createState() => _ManualListPageState();
 }

--- a/mobile/lib/pages/my_shift_page.dart
+++ b/mobile/lib/pages/my_shift_page.dart
@@ -60,6 +60,8 @@ List<dynamic>? _getCashedShiftCardDataList(int dayID, int weatherID) {
 }
 
 class MyShiftPage extends StatefulWidget {
+  const MyShiftPage({super.key});
+
   @override
   _MyShiftPageState createState() => _MyShiftPageState();
 }

--- a/mobile/lib/pages/rescue/rescue_request_tab/rescue_request_tab.dart
+++ b/mobile/lib/pages/rescue/rescue_request_tab/rescue_request_tab.dart
@@ -3,6 +3,8 @@ import 'package:seeft_mobile/pages/rescue/rescue_request_tab/tab_pages/home.dart
 
 // 「レスキューを送信する」タブ
 class RescueRequestTab extends StatelessWidget {
+  const RescueRequestTab({super.key});
+
   @override
   Widget build(BuildContext context) {
     // ネストされたNavigatorを使用して、タブ内で独立したナビゲーションを可能にする

--- a/mobile/lib/pages/rescue/rescue_request_tab/tab_pages/home.dart
+++ b/mobile/lib/pages/rescue/rescue_request_tab/tab_pages/home.dart
@@ -8,6 +8,8 @@ class RescueRequestTabHome extends StatelessWidget {
   // 環境変数から委員長の名前と電話番号を取得
   final String chairpersonName = constant.chairpersonName;
   final String chairpersonPhoneNumber = constant.chairpersonPhoneNumber;
+
+  RescueRequestTabHome({super.key});
   @override
   Widget build(BuildContext context) {
     return Center(

--- a/mobile/lib/pages/sign_in_page.dart
+++ b/mobile/lib/pages/sign_in_page.dart
@@ -2,6 +2,8 @@ import 'package:seeft_mobile/configs/importer.dart';
 import 'package:seeft_mobile/widgets/app_bar.dart';
 
 class SignInPage extends StatefulWidget {
+  const SignInPage({super.key});
+
   @override
   _SignInPageState createState() => _SignInPageState();
 }

--- a/mobile/lib/pages/users_page.dart
+++ b/mobile/lib/pages/users_page.dart
@@ -7,6 +7,8 @@ import 'package:url_launcher/url_launcher.dart';
 import 'package:seeft_mobile/pages/wait_page.dart';
 
 class UsersPage extends StatefulWidget {
+  const UsersPage({super.key});
+
   @override
   _UsersPageState createState() => _UsersPageState();
 }

--- a/mobile/lib/pages/wait_page.dart
+++ b/mobile/lib/pages/wait_page.dart
@@ -5,6 +5,8 @@ import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class WaitPage extends StatefulWidget {
+  const WaitPage({super.key});
+
   @override
   _WaitPageState createState() => new _WaitPageState();
 }

--- a/mobile/lib/widgets/first_jump_selector.dart
+++ b/mobile/lib/widgets/first_jump_selector.dart
@@ -3,6 +3,8 @@ import 'package:seeft_mobile/pages/sign_in_page.dart';
 import 'package:seeft_mobile/widgets/layout.dart';
 
 class FirstJumpSelector extends StatefulWidget {
+  const FirstJumpSelector({super.key});
+
   @override
   _FirstJumpSelectorState createState() => new _FirstJumpSelectorState();
 }


### PR DESCRIPTION
## 概要

flutter_lints の `use_key_in_widget_constructors` 違反8件を解消します（親 #286 / 子 #292）。

公開ウィジェットのコンストラクタに `key` パラメータがないと、呼び出し元が `key` を渡せません。`key` は Flutter がウィジェットツリーの差分更新時に個体を識別するための名札で、動的なリストの並び替え・削除時に State を正しい Widget に引き継ぐために必要です。

```dart
// Before
class MyWidget extends StatelessWidget {
  const MyWidget();
}

// After
class MyWidget extends StatelessWidget {
  const MyWidget({super.key});
}
```

## 変更内容

`fvm dart fix --apply --code=use_key_in_widget_constructors` による機械修正を適用しました。`home.dart` のみ、フィールドが実行時の環境変数で初期化されているため `const` コンストラクタと矛盾が生じたため、`const` を手動で除去しました。

```text
mobile/lib/pages/manual_list_page.dart                              1件
mobile/lib/pages/my_shift_page.dart                                 1件
mobile/lib/pages/rescue/rescue_request_tab/rescue_request_tab.dart  1件
mobile/lib/pages/rescue/rescue_request_tab/tab_pages/home.dart      1件（const を手動除去）
mobile/lib/pages/sign_in_page.dart                                  1件
mobile/lib/pages/users_page.dart                                    1件
mobile/lib/pages/wait_page.dart                                     1件
mobile/lib/widgets/first_jump_selector.dart                         1件
```

## 確認

```bash
cd mobile && fvm flutter analyze 2>&1 | grep "use_key_in_widget_constructors" | tee /dev/stderr | wc -l | xargs -I{} sh -c 'if [ "{}" = "0" ]; then echo "OK: use_key_in_widget_constructors 0件"; else echo "NG: {}件残っています"; fi'
```

`use_key_in_widget_constructors` が0件になることを確認済み。

Closes #292