### PR TITLE
fix: 文字列展開の不要な {} を削除 #293

### DIFF
--- a/mobile/lib/pages/my_shift_page.dart
+++ b/mobile/lib/pages/my_shift_page.dart
@@ -44,7 +44,7 @@ Future<List<dynamic>?> _getShiftCardDataList(int userID, int dayID, int weatherI
 List<dynamic>? _getCashedShiftCardDataList(int dayID, int weatherID) {
   // キャッシュからデータを取得
   logger.i('=== キャッシュからデータを取得します ===');
-  final List<dynamic>? cachedData = shiftCardBox.get('${dayID}_${weatherID}');
+  final List<dynamic>? cachedData = shiftCardBox.get('${dayID}_$weatherID');
   logger.i('キャッシュデータの取得に成功しました: ${cachedData != null ? cachedData.length : 'null'} items');
   
   // キャッシュデータがない場合は表示データをnullに設定する
@@ -278,7 +278,7 @@ class _MyShiftPageState extends State<MyShiftPage>
       }
       
       // hiveのキャッシュデータをフェッチデータで更新
-      shiftCardBox.put('${dayID}_${weatherID}', fetchedData);
+      shiftCardBox.put('${dayID}_$weatherID', fetchedData);
       // 最新データに存在しない既読キーを掃除
       if (fetchedShiftCardDataList != null) {
         _cleanupStaleOpenedKeys(dayID, fetchedShiftCardDataList);

--- a/mobile/lib/pages/rescue/rescue_request_tab/tab_pages/shorthanded.dart
+++ b/mobile/lib/pages/rescue/rescue_request_tab/tab_pages/shorthanded.dart
@@ -27,7 +27,7 @@ class RescueRequestTabShorthandedPage extends StatelessWidget {
       if (res is List) {
         logger.i('Response is List with ${res.length} items');
         if (res.isNotEmpty) {
-          logger.i('First item: ${res}');
+          logger.i('First item: $res');
         }
       } else {
         logger.w('Response is not a List, it is: ${res.runtimeType}');

--- a/mobile/lib/pages/rescue/rescue_request_tab/tab_pages/trouble.dart
+++ b/mobile/lib/pages/rescue/rescue_request_tab/tab_pages/trouble.dart
@@ -27,7 +27,7 @@ class RescueRequestTabTroublePage extends StatelessWidget {
       if (res is List) {
         logger.i('Response is List with ${res.length} items');
         if (res.isNotEmpty) {
-          logger.i('First item: ${res}');
+          logger.i('First item: $res');
         }
       } else {
         logger.w('Response is not a List, it is: ${res.runtimeType}');

--- a/mobile/lib/pages/rescue/rescue_response_tab/rescue_response_tab.dart
+++ b/mobile/lib/pages/rescue/rescue_response_tab/rescue_response_tab.dart
@@ -40,7 +40,7 @@ List<dynamic>? _getCashedRescueResponses(int? userID) {
     // userIDがnullの場合は全てのレスキューのレスポンスを取得
     cachedData = rescueBox.get('all_rescue_responses');
   } else {
-    cachedData = rescueBox.get('rescue_responses_by_${userID}');
+    cachedData = rescueBox.get('rescue_responses_by_$userID');
   }
   // final List<dynamic>? cachedData = rescueBox.get('rescue_responses_by_${userID}');
   logger.i('キャッシュデータの取得に成功しました: ${cachedData != null ? cachedData.length : 'null'} items');

--- a/mobile/lib/pages/sign_in_page.dart
+++ b/mobile/lib/pages/sign_in_page.dart
@@ -26,7 +26,7 @@ class _SignInPageState extends State<SignInPage> {
         // userIdをstoreにset出来てるか確認
         var userID = await store.getUserID();
         setState(() {
-          infoText = "Your ID : ${userID}";
+          infoText = "Your ID : $userID";
         });
         Navigator.pushNamedAndRemoveUntil(
             context,


### PR DESCRIPTION
## 概要

flutter_lints の `unnecessary_brace_in_string_interps` 違反6件を解消します（親 #286 / 子 #293）。

変数1つをそのまま展開するだけの場合、`${}` の波括弧は不要です。式や `.` アクセスを含む場合のみ `${}` が必要です。

```dart
// Before
"Hello ${name}!"

// After
"Hello $name!"
```

## 変更内容

`fvm dart fix --apply --code=unnecessary_brace_in_string_interps` による機械修正です。挙動の変更はありません。

```text
mobile/lib/pages/my_shift_page.dart                                    2件
mobile/lib/pages/rescue/rescue_request_tab/tab_pages/shorthanded.dart  1件
mobile/lib/pages/rescue/rescue_request_tab/tab_pages/trouble.dart      1件
mobile/lib/pages/rescue/rescue_response_tab/rescue_response_tab.dart   1件
mobile/lib/pages/sign_in_page.dart                                     1件
```

## 確認

```bash
cd mobile && fvm flutter analyze 2>&1 | grep "unnecessary_brace_in_string_interps" | tee /dev/stderr | wc -l | xargs -I{} sh -c 'if [ "{}" = "0" ]; then echo "OK: unnecessary_brace_in_string_interps 0件"; else echo "NG: {}件残っています"; fi'
```

`unnecessary_brace_in_string_interps` が0件になることを確認済み。

Closes #293

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * キャッシュキー生成ロジックを最適化しました。
  * ログ出力の文字列処理を改善しました。
  * 内部コード品質の向上を実施しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->