### PR TITLE
fix: child/children プロパティを最後に移動 #296

### DIFF
--- a/mobile/lib/pages/sign_in_page.dart
+++ b/mobile/lib/pages/sign_in_page.dart
@@ -270,13 +270,6 @@ class _SignInPageState extends State<SignInPage> {
                           borderRadius: BorderRadius.circular(8.0),
                         ),
                         child: ElevatedButton(
-                          child: const Text(
-                            'ログイン',
-                            style: TextStyle(
-                              fontSize: AppFontSizes.sm,
-                              color: AppColors.textWhite,
-                            ),
-                          ),
                           style: ElevatedButton.styleFrom(
                             backgroundColor: AppColors.main,
                             padding: const EdgeInsets.symmetric(
@@ -287,6 +280,13 @@ class _SignInPageState extends State<SignInPage> {
                           onPressed: () async {
                             _signIn();
                           },
+                          child: const Text(
+                            'ログイン',
+                            style: TextStyle(
+                              fontSize: AppFontSizes.sm,
+                              color: AppColors.textWhite,
+                            ),
+                          ),
                         ),
                       ),
                       Container(

--- a/mobile/lib/widgets/review_bottom_sheet.dart
+++ b/mobile/lib/widgets/review_bottom_sheet.dart
@@ -160,6 +160,7 @@ class _ReviewFormState extends State<ReviewForm> {
           ),
           const SizedBox(height: 8),
           Visibility(
+            visible: _isFailed,
             child: Text(
               "送信に失敗しました。もう一度お試しください。",
               style: TextStyle(
@@ -167,7 +168,6 @@ class _ReviewFormState extends State<ReviewForm> {
                 fontSize: AppFontSizes.sm,
               )
             ),
-            visible: _isFailed,
           ),
           Row(
             spacing: 8.0,

--- a/mobile/lib/widgets/table.dart
+++ b/mobile/lib/widgets/table.dart
@@ -18,25 +18,25 @@ class ShiftTable {
           TableRow(children: [
             TableCell(
                 child: Container(
+              alignment: Alignment.center,
+              color: Colors.orangeAccent,
               child: Text(
                 "日時",
                 style: TextStyle(
                   color: Colors.white,
                 ),
               ),
-              alignment: Alignment.center,
-              color: Colors.orangeAccent,
             )),
             TableCell(
               child: Container(
+                alignment: Alignment.center,
+                color: Colors.orangeAccent,
                 child: Text(
                   "シフト",
                   style: TextStyle(
                     color: Colors.white,
                   ),
                 ),
-                alignment: Alignment.center,
-                color: Colors.orangeAccent,
               ),
             )
           ]),


### PR DESCRIPTION
## 概要

flutter_lints の `sort_child_properties_last` 違反4件を解消します（親 #286 / 子 #296）。

ウィジェットの `child` / `children` は必ず引数の最後に置くルールです。子ウィジェットのツリーは行数が多くなりがちなため、最後に統一することで「プロパティ設定 → 子の定義」という読み順が明確になります。

```dart
// Before
Container(
  child: Text("hello"),
  color: Colors.red,
)

// After
Container(
  color: Colors.red,
  child: Text("hello"),
)
```

## 変更内容

`fvm dart fix --apply --code=sort_child_properties_last` による機械修正です。挙動の変更はありません。

```text
mobile/lib/pages/sign_in_page.dart          複数件
mobile/lib/widgets/review_bottom_sheet.dart 1件
mobile/lib/widgets/table.dart               複数件
```

## 確認

```bash
cd mobile && fvm flutter analyze 2>&1 | grep "sort_child_properties_last" | tee /dev/stderr | wc -l | xargs -I{} sh -c 'if [ "{}" = "0" ]; then echo "OK: sort_child_properties_last 0件"; else echo "NG: {}件残っています"; fi'
```

`sort_child_properties_last` が0件になることを確認済み。

Closes #296