### PR TITLE
fix: 二重の import を削除 #298

### DIFF
--- a/mobile/lib/widgets/rescue_dialog.dart
+++ b/mobile/lib/widgets/rescue_dialog.dart
@@ -1,6 +1,4 @@
-import 'package:flutter/material.dart';
 import 'package:seeft_mobile/configs/importer.dart';
-import 'package:flutter/services.dart';
 
 //1ページ目とその表示
 Future<void> openRescueDialog(BuildContext context,) async {

--- a/mobile/lib/widgets/shift_dialog.dart
+++ b/mobile/lib/widgets/shift_dialog.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/material.dart';
 import 'package:seeft_mobile/configs/importer.dart';
 import 'package:url_launcher/url_launcher.dart';
 


### PR DESCRIPTION
## 概要

analyzer の `unnecessary_import` 警告3件を解消します（親 #286 / 子 #298）。

別の import 経由ですでに解決できるパッケージを二重に import している箇所を削除します。`flutter/material.dart` は `flutter/widgets.dart` 等を内部で re-export しているため、`material.dart` だけで十分です。

```dart
// Before
import 'package:flutter/widgets.dart';   // ← 不要（material.dart が内包）
import 'package:flutter/material.dart';

// After
import 'package:flutter/material.dart';
```

## 変更内容

`fvm dart fix --apply --code=unnecessary_import` による機械修正です。挙動の変更はありません。

```text
mobile/lib/widgets/rescue_dialog.dart  2件
mobile/lib/widgets/shift_dialog.dart   1件
```

## 確認

```bash
cd mobile && fvm flutter analyze 2>&1 | grep "unnecessary_import" | tee /dev/stderr | wc -l | xargs -I{} sh -c 'if [ "{}" = "0" ]; then echo "OK: unnecessary_import 0件"; else echo "NG: {}件残っています"; fi'
```

`unnecessary_import` が0件になることを確認済み。

Closes #298