### PR TITLE
fix: StatelessWidget のコンストラクタに const を付与 #300

### DIFF
--- a/mobile/lib/pages/rescue/rescue_request_tab/tab_pages/question.dart
+++ b/mobile/lib/pages/rescue/rescue_request_tab/tab_pages/question.dart
@@ -7,7 +7,7 @@ import 'package:seeft_mobile/widgets/custom_snack_bar.dart';
 import 'package:seeft_mobile/widgets/custom_error_snack_bar.dart';
 
 class RescueRequestTabQuestionPage extends StatelessWidget {
-  RescueRequestTabQuestionPage({
+  const RescueRequestTabQuestionPage({
     super.key,
   });
   

--- a/mobile/lib/pages/rescue/rescue_request_tab/tab_pages/shorthanded.dart
+++ b/mobile/lib/pages/rescue/rescue_request_tab/tab_pages/shorthanded.dart
@@ -9,7 +9,7 @@ import 'package:seeft_mobile/widgets/custom_snack_bar.dart';
 import 'package:seeft_mobile/widgets/custom_error_snack_bar.dart';
 
 class RescueRequestTabShorthandedPage extends StatelessWidget {
-  RescueRequestTabShorthandedPage({
+  const RescueRequestTabShorthandedPage({
     super.key,
   });
   

--- a/mobile/lib/pages/rescue/rescue_request_tab/tab_pages/trouble.dart
+++ b/mobile/lib/pages/rescue/rescue_request_tab/tab_pages/trouble.dart
@@ -9,7 +9,7 @@ import 'package:seeft_mobile/widgets/custom_snack_bar.dart';
 import 'package:seeft_mobile/widgets/custom_error_snack_bar.dart';
 
 class RescueRequestTabTroublePage extends StatelessWidget {
-  RescueRequestTabTroublePage({
+  const RescueRequestTabTroublePage({
     super.key,
   });
   


### PR DESCRIPTION
## 概要

flutter_lints の `prefer_const_constructors_in_immutables` 違反3件を解消します（親 #286 / 子 #300）。

`StatelessWidget` を継承したクラスは `@immutable`（全フィールドが `final`）であるため、コンストラクタを `const` にできます。`const` コンストラクタがあると呼び出し元が `const MyWidget()` と書けるようになり、Flutter が再描画時にインスタンスを使い回してパフォーマンスが向上します。

```dart
// Before
RescueRequestTabTroublePage({super.key});

// After
const RescueRequestTabTroublePage({super.key});
```

## 変更内容

手動修正です。挙動の変更はありません。

```text
mobile/lib/pages/rescue/rescue_request_tab/tab_pages/question.dart    1件
mobile/lib/pages/rescue/rescue_request_tab/tab_pages/shorthanded.dart 1件
mobile/lib/pages/rescue/rescue_request_tab/tab_pages/trouble.dart     1件
```

## 確認

```bash
cd mobile && fvm flutter analyze 2>&1 | grep "prefer_const_constructors_in_immutables" | tee /dev/stderr | wc -l | xargs -I{} sh -c 'if [ "{}" = "0" ]; then echo "OK: prefer_const_constructors_in_immutables 0件"; else echo "NG: {}件残っています"; fi'
```

`prefer_const_constructors_in_immutables` が0件になることを確認済み。

Closes #300