### PR TITLE
fix: 文字列連結を + から文字列展開 $ に統一 #283

### DIFF
--- a/mobile/lib/pages/my_shift_page.dart
+++ b/mobile/lib/pages/my_shift_page.dart
@@ -338,7 +338,7 @@ class _MyShiftPageState extends State<MyShiftPage>
       
       // シフトカードからタスクの終了時刻を取得
       final String endTime = shiftCard.endTime.padLeft(5, '0'); // 1桁時間の場合に備えて0埋め
-      DateTime shiftEndTime = DateTime.parse("$targetDate " + endTime);
+      DateTime shiftEndTime = DateTime.parse("$targetDate $endTime");
       print("現在時刻: $now, シフト終了時刻: $shiftEndTime");
       
       // 対象のタスクが終了しているかどうかを判定

--- a/mobile/lib/pages/rescue/rescue_request_tab/tab_pages/home.dart
+++ b/mobile/lib/pages/rescue/rescue_request_tab/tab_pages/home.dart
@@ -174,10 +174,10 @@ class RescueRequestTabHome extends StatelessWidget {
                         children: [
                           Text(
                             // 電話番号をハイフンありの形式に変換
-                            chairpersonName + "\n" + chairpersonPhoneNumber.replaceAllMapped(
+                            "$chairpersonName\n${chairpersonPhoneNumber.replaceAllMapped(
                               RegExp(r'(\d{3})(\d{4})(\d{4})'),
                               (Match m) => '${m[1]}-${m[2]}-${m[3]}',
-                            ),
+                            )}",
                             style: TextStyle(
                               fontSize: AppFontSizes.md,
                               color: AppColors.error,
@@ -228,7 +228,7 @@ class RescueRequestTabHome extends StatelessWidget {
 // 電話アプリを開く関数
 void _openPhoneApp(String phoneNumber) async {
   _launchURL(
-    'tel:' + phoneNumber,
+    'tel:$phoneNumber',
   );
 }
 

--- a/mobile/lib/pages/rescue/rescue_response_tab/rescue_response_tab.dart
+++ b/mobile/lib/pages/rescue/rescue_response_tab/rescue_response_tab.dart
@@ -274,36 +274,27 @@ class _RescueResponseTabState extends State<RescueResponseTab> {
   // レスキューのレスポンスを表示するウィジェット
   Widget _rescueResponseWidget(RescueResponse response) {
     String titleRescue = "";
-    String titleResponse = response.response == "" ? "本部からの返答はまだありません。" : "本部からの返答: " + response.response;
+    String titleResponse = response.response == "" ? "本部からの返答はまだありません。" : "本部からの返答: ${response.response}";
     String subTitle = "";
     // レスキューのタイプに応じてタイトルとサブタイトルを設定
     switch(response.type) {
       // トラブル
       case 'trouble':
         final res = response as TroubleRescueResponse;
-        titleRescue = "【トラブル】" + res.content.detail;
-        subTitle = "対応番号: T" + res.id.toString() + "\n"
-                  + "送信者: " + res.userName + "\n"
-                  + "発生タスク: " + res.content.task + "\n"
-                  + "発生場所: " + res.content.place + "\n"
-                  + "発生時刻: " + res.time;
+        titleRescue = "【トラブル】${res.content.detail}";
+        subTitle = "対応番号: T${res.id}\n送信者: ${res.userName}\n発生タスク: ${res.content.task}\n発生場所: ${res.content.place}\n発生時刻: ${res.time}";
         break;
       // 質問
       case 'question':
         final res = response as QuestionRescueResponse;
-        titleRescue = "【質問】" + res.content.question;
-        subTitle = "対応番号: Q" + res.id.toString() + "\n"
-                  + "送信者: " + res.userName + "\n"
-                  + "発生時刻: " + res.time;
+        titleRescue = "【質問】${res.content.question}";
+        subTitle = "対応番号: Q${res.id}\n送信者: ${res.userName}\n発生時刻: ${res.time}";
         break;
       // 人が来ない
       case 'shorthanded':
         final res = response as ShorthandedRescueResponse;
-        titleRescue = "【人が来ない】" + res.content.task + "（" + res.content.missingNumber.toString() + "人）";
-        subTitle = "対応番号: S" + res.id.toString() + "\n"
-                  + "送信者: " + res.userName + "\n"
-                  + "送り先の場所: " + res.content.place + "\n"
-                  + "発生時刻: " + res.time;
+        titleRescue = "【人が来ない】${res.content.task}（${res.content.missingNumber}人）";
+        subTitle = "対応番号: S${res.id}\n送信者: ${res.userName}\n送り先の場所: ${res.content.place}\n発生時刻: ${res.time}";
         break;
     }
     return ListTile(
@@ -311,7 +302,7 @@ class _RescueResponseTabState extends State<RescueResponseTab> {
         TextSpan(
           children: [
             TextSpan(
-              text: titleRescue + "\n",
+              text: "$titleRescue\n",
               style: TextStyle(
                 fontSize: AppFontSizes.md,
                 color: AppColors.textBlack,

--- a/mobile/lib/pages/users_page.dart
+++ b/mobile/lib/pages/users_page.dart
@@ -188,7 +188,7 @@ class _UsersPageState extends State<UsersPage> {
 
 void _openPhoneApp(String tel_number) {
   _launchURL(
-    'tel:' + tel_number,
+    'tel:$tel_number',
   );
 }
 

--- a/mobile/lib/utils/api.dart
+++ b/mobile/lib/utils/api.dart
@@ -66,7 +66,7 @@ class Api {
 
 // Example
   Future getMyShift(id) async {
-    String url = constant.apiUrl + '/shifts/users/' + id;
+    String url = '${constant.apiUrl}/shifts/users/$id';
     try {
       return await get(url);
     } catch (err) {
@@ -79,7 +79,7 @@ class Api {
   // 準備日晴れシフト
   Future getMyShiftPreparationDaySunny(id) async {
     String url =
-        constant.apiUrl + '/shifts/users/' + id + '/dates/1/weathers/1';
+        '${constant.apiUrl}/shifts/users/$id/dates/1/weathers/1';
     try {
       return await get(url);
     } catch (err) {
@@ -93,7 +93,7 @@ class Api {
   Future getMyShiftPreparationDayRainy(id) async {
     // String url = constant.apiUrl + '/shifts/users/' + id + '/dates/1/weathers/2';
     String url =
-        constant.apiUrl + '/shifts/users/' + id + '/dates/1/weathers/2';
+        '${constant.apiUrl}/shifts/users/$id/dates/1/weathers/2';
     try {
       return await get(url);
     } catch (err) {
@@ -107,7 +107,7 @@ class Api {
   Future getMyShiftCurrentFirstDaySunny(id) async {
     // 一旦準備日のseedデータを使用
     String url =
-        constant.apiUrl + '/shifts/users/' + id + '/dates/2/weathers/1';
+        '${constant.apiUrl}/shifts/users/$id/dates/2/weathers/1';
     //String url = constant.apiUrl + '/shifts/users/' + id + '/dates/1/weathers/1';
     try {
       return await get(url);
@@ -123,7 +123,7 @@ class Api {
     // 一旦準備日のseedデータを使用
     // String url = constant.apiUrl + '/shifts/users/' + id + '/dates/2/weathers/2';
     String url =
-        constant.apiUrl + '/shifts/users/' + id + '/dates/2/weathers/2';
+        '${constant.apiUrl}/shifts/users/$id/dates/2/weathers/2';
     try {
       return await get(url);
     } catch (err) {
@@ -137,7 +137,7 @@ class Api {
   Future getMyShiftCurrentSecondDaySunny(id) async {
     // 一旦準備日のseedデータを使用
     String url =
-        constant.apiUrl + '/shifts/users/' + id + '/dates/3/weathers/1';
+        '${constant.apiUrl}/shifts/users/$id/dates/3/weathers/1';
     //String url = constant.apiUrl + '/shifts/users/' + id + '/dates/1/weathers/1';
     try {
       return await get(url);
@@ -153,7 +153,7 @@ class Api {
     // 一旦準備日のseedデータを使用
     // String url = constant.apiUrl + '/shifts/users/' + id + '/dates/3/weathers/2';
     String url =
-        constant.apiUrl + '/shifts/users/' + id + '/dates/3/weathers/2';
+        '${constant.apiUrl}/shifts/users/$id/dates/3/weathers/2';
     try {
       return await get(url);
     } catch (err) {
@@ -168,7 +168,7 @@ class Api {
     // 一旦準備日のseedデータを使用
     // String url = constant.apiUrl + '/shifts/users/' + id + '/dates/4/weathers/1';
     String url =
-        constant.apiUrl + '/shifts/users/' + id + '/dates/4/weathers/1';
+        '${constant.apiUrl}/shifts/users/$id/dates/4/weathers/1';
     try {
       return await get(url);
     } catch (err) {
@@ -181,17 +181,7 @@ class Api {
   // シフトのユーザ取得
   Future getUsersByShift(String task, String year, String date, String time,
       String weather) async {
-    String url = constant.apiUrl +
-        '/shifts/tasks/' +
-        task +
-        '/years/' +
-        year +
-        '/dates/' +
-        date +
-        '/times/' +
-        time +
-        '/weathers/' +
-        weather;
+    String url = '${constant.apiUrl}/shifts/tasks/$task/years/$year/dates/$date/times/$time/weathers/$weather';
     try {
       return await get(url);
     } catch (err) {
@@ -203,7 +193,7 @@ class Api {
 
   // マニュアル一覧
   Future getAllManual() async {
-    String url = constant.apiUrl + '/tasks';
+    String url = '${constant.apiUrl}/tasks';
     try {
       return await get(url);
     } catch (err) {
@@ -215,7 +205,7 @@ class Api {
 
   // 局情報
   Future getBureausId() async {
-    String url = constant.apiUrl + '/bureaus';
+    String url = '${constant.apiUrl}/bureaus';
     try {
       return await get(url);
     } catch (err) {
@@ -227,7 +217,7 @@ class Api {
 
   // ユーザ一覧
   Future getUsers() async {
-    String url = constant.apiUrl + '/users';
+    String url = '${constant.apiUrl}/users';
     try {
       return await get(url);
     } catch (err) {
@@ -238,7 +228,7 @@ class Api {
 
   // POST Sign In (リダイレクションエラーが返ってくるため不使用)
   Future postSignIn(request) async {
-    var url = Uri.parse(constant.apiUrl + '/auth');
+    var url = Uri.parse('${constant.apiUrl}/auth');
     var response = await http.post(url,
         body: {'mail': 'y.kugue.nutfes@gmail.com', 'password': 'gidaifes'});
 
@@ -254,11 +244,7 @@ class Api {
   // Get Sign In
   Future signIn(studentNumber, password) async {
     //var url = constant.apiUrl + "/mail_auth/signin?email=" + mail;
-    String url = constant.apiUrl +
-        '/mail_auth/signin?student_number=' +
-        studentNumber +
-        '&password=' +
-        password;
+    String url = '${constant.apiUrl}/mail_auth/signin?student_number=$studentNumber&password=$password';
     // String url = constant.apiUrl + '/mail_auth/signin';
     // var body = {'student_number': studentNumber};
     // logger.i(url);
@@ -295,7 +281,7 @@ class Api {
   // Get Shift Detail
   Future shiftDetail(workId, userId, date, weather, time) async {
     // logger.w(time);
-    var url = constant.apiUrl + "/tasks/shifts/" + workId.toString();
+    var url = "${constant.apiUrl}/tasks/shifts/$workId";
     try {
       logger.i(url);
       var res = await get(url);
@@ -309,7 +295,7 @@ class Api {
   
   // シフトカードの情報を取得する
   Future getShiftCardsByUserAndDateAndWeather(int userId, int dateId, int weatherId) async {
-    var url = constant.apiUrl + "/shift-cards/users/" + userId.toString() + "/dates/" + dateId.toString() + "/weathers/" + weatherId.toString();
+    var url = "${constant.apiUrl}/shift-cards/users/$userId/dates/$dateId/weathers/$weatherId";
     try {
       logger.i(url);
       var res = await get(url);
@@ -323,7 +309,7 @@ class Api {
   
   // 指定したユーザIDに紐づくタスクを取得
   Future getTasksByUserID(String userId) async {
-    var url = constant.apiUrl + "/tasks/users/" + userId;
+    var url = "${constant.apiUrl}/tasks/users/$userId";
     try {
       logger.i(url);
       var res = await get(url);
@@ -337,7 +323,7 @@ class Api {
   
   // IDで指定したユーザが送信したレスキューの一覧を取得する
   Future getRescueResponses(int userID) async {
-    var url = constant.apiUrl + "/rescues/users/" + userID.toString();
+    var url = "${constant.apiUrl}/rescues/users/$userID";
     try {
       logger.i(url);
       var res = await get(url);
@@ -345,21 +331,21 @@ class Api {
       // return (res as List).map((item) => RescueResponse.fromJson(item)).toList();
       return res;
     } catch (e) {
-      logger.e('failed got:' + e.toString());
+      logger.e('failed got:$e');
       throw Exception('Failed GET in Api.getRescueResponses()');
     }
   }
   
   // レスキューの一覧を取得する
   Future getAllRescueResponses() async {
-    var url = constant.apiUrl + "/rescues";
+    var url = "${constant.apiUrl}/rescues";
     try {
       logger.i(url);
       var res = await get(url);
       logger.i(res);
       return res;
     } catch (e) {
-      logger.e('failed got:' + e.toString());
+      logger.e('failed got:$e');
       throw Exception('Failed GET in Api.getAllRescueResponses()');
     }
   }
@@ -371,7 +357,7 @@ class Api {
     String place,
     String detail,
   ) async {
-    final url = constant.apiUrl + "/rescues";
+    final url = "${constant.apiUrl}/rescues";
     final uri = Uri.parse(url);
     logger.i(uri);
     final body = {
@@ -406,7 +392,7 @@ class Api {
     int userID,
     String question,
   ) async {
-    final url = constant.apiUrl + "/rescues";
+    final url = "${constant.apiUrl}/rescues";
     final uri = Uri.parse(url);
     logger.i(uri);
     final body = {
@@ -441,7 +427,7 @@ class Api {
     int missingNumber,
     String place,
   ) async {
-    final url = constant.apiUrl + "/rescues";
+    final url = "${constant.apiUrl}/rescues";
     final uri = Uri.parse(url);
     logger.i(uri);
     final body = {
@@ -479,7 +465,7 @@ class Api {
     int manualRating,
     String comment,
   ) async {
-    final url = constant.apiUrl + "/reviews";
+    final url = "${constant.apiUrl}/reviews";
     final uri = Uri.parse(url);
     logger.i(uri);
     final body = {

--- a/mobile/lib/widgets/review_bottom_sheet.dart
+++ b/mobile/lib/widgets/review_bottom_sheet.dart
@@ -136,7 +136,7 @@ class _ReviewFormState extends State<ReviewForm> {
         spacing: 8,
         children: [
           Text(
-            "シフトのレビュー: " + widget.taskName,
+            "シフトのレビュー: ${widget.taskName}",
             style: TextStyle(
               color: AppColors.textBlack,
               fontSize: AppFontSizes.md,

--- a/mobile/lib/widgets/shift_card.dart
+++ b/mobile/lib/widgets/shift_card.dart
@@ -62,7 +62,7 @@ class ShiftCard extends StatelessWidget {
                     ),
                     const SizedBox(width: 2.0),
                     Text(
-                      data.startTime + "〜" + data.endTime,
+                      "${data.startTime}〜${data.endTime}",
                       style: const TextStyle(
                         fontSize: AppFontSizes.sm,
                         color: AppColors.textBlack
@@ -153,16 +153,14 @@ class ShiftCard extends StatelessWidget {
                     title: '【担当者の一覧】',
                     content: [
                       for (var member in data.shiftMembers)
-                        '${member.s_time}〜${member.e_time}\n' +
-                        member.members.map((m) => '(${m.bureau}${m.grade}) ${m.name}').join(', '),
+                        '${member.s_time}〜${member.e_time}\n${member.members.map((m) => '(${m.bureau}${m.grade}) ${m.name}').join(', ')}',
                     ],
                   ),
                   _buildSection(
                     title: '【前の時間の担当者の一覧】',
                     content: [
                       if (data.beforeMembers.members.isNotEmpty)
-                        '${data.beforeMembers.s_time}〜${data.beforeMembers.e_time}\n' +
-                        data.beforeMembers.members.map((m) => '(${m.bureau}${m.grade}) ${m.name}').join(', ')
+                        '${data.beforeMembers.s_time}〜${data.beforeMembers.e_time}\n${data.beforeMembers.members.map((m) => '(${m.bureau}${m.grade}) ${m.name}').join(', ')}'
                       else
                         '前の時間の担当者はいません',
                     ],
@@ -171,8 +169,7 @@ class ShiftCard extends StatelessWidget {
                     title: '【次の時間の担当者の一覧】',
                     content: [
                       if (data.afterMembers.members.isNotEmpty)
-                        '${data.afterMembers.s_time}〜${data.afterMembers.e_time}\n' +
-                        data.afterMembers.members.map((m) => '(${m.bureau}${m.grade}) ${m.name}').join(', ')
+                        '${data.afterMembers.s_time}〜${data.afterMembers.e_time}\n${data.afterMembers.members.map((m) => '(${m.bureau}${m.grade}) ${m.name}').join(', ')}'
                       else
                         '次の時間の担当者はいません',
                     ],

--- a/mobile/lib/widgets/table.dart
+++ b/mobile/lib/widgets/table.dart
@@ -101,7 +101,7 @@ class HexColor extends Color {
     hexColor = hexColor.toUpperCase().replaceAll('0X', '');
     // logger.d(hexColor);
     if (hexColor.length == 6) {
-      hexColor = 'FF' + hexColor;
+      hexColor = 'FF$hexColor';
     }
     // logger.d(hexColor);
     return int.parse(hexColor, radix: 16);


### PR DESCRIPTION
## 概要

flutter_lints の `prefer_interpolation_to_compose_strings` 違反60件を解消します（親 #286 / 子 #283）。

文字列を `+` で連結するより `$変数名` / `${式}` の文字列展開の方が読みやすく、`.toString()` の明示も不要になります。

```dart
// Before
String url = '${constant.apiUrl}/shifts/users/' + id + '/dates/1/weathers/1';

// After
String url = '${constant.apiUrl}/shifts/users/$id/dates/1/weathers/1';
```

## 変更内容

43件は `fvm dart fix --apply --code=prefer_interpolation_to_compose_strings` で自動修正。残り17件（`api.dart` の URL 組み立て、その他）は変数が左端にある等のパターンで自動変換できないため手動修正しました。挙動の変更はありません。

```text
mobile/lib/pages/my_shift_page.dart                                   1件
mobile/lib/pages/rescue/rescue_request_tab/tab_pages/home.dart        複数件
mobile/lib/pages/rescue/rescue_response_tab/rescue_response_tab.dart  複数件
mobile/lib/pages/users_page.dart                                      1件
mobile/lib/utils/api.dart                                             複数件
mobile/lib/widgets/review_bottom_sheet.dart                           1件
mobile/lib/widgets/shift_card.dart                                    複数件
mobile/lib/widgets/table.dart                                         1件
```

## 確認

```bash
fvm flutter analyze 2>&1 | grep "prefer_interpolation_to_compose_strings" | tee /dev/stderr | wc -l | xargs -I{} sh -c 'if [ "{}" = "0" ]; then echo "OK: prefer_interpolation_to_compose_strings 0件"; else echo "NG: {}件残っています"; fi'
```

`prefer_interpolation_to_compose_strings` が0件になることを確認済み。

Closes #283

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * シフト管理、レスキュー機能、ユーザーページなど複数の機能にわたるコード品質改善を実施しました。システムの安定性と保守性が向上しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->