### PR TITLE
fix: 変数名をスネークケースから lowerCamelCase に統一 #294

### DIFF
--- a/mobile/lib/models/shift_card.dart
+++ b/mobile/lib/models/shift_card.dart
@@ -11,13 +11,13 @@ class ShiftMember {
   });
 }
 class ShiftMembers {
-  final String s_time;
-  final String e_time;
+  final String sTime;
+  final String eTime;
   final List<ShiftMember> members;
 
   ShiftMembers({
-    required this.s_time,
-    required this.e_time,
+    required this.sTime,
+    required this.eTime,
     required this.members,
   });
 }
@@ -60,8 +60,8 @@ class ShiftCardDataList {
       shiftMembers: item['shift_members'] != null?
         (item['shift_members'] as List<dynamic>)
           .map((member) => ShiftMembers(
-                s_time: member['s_time'],
-                e_time: member['e_time'],
+                sTime: member['s_time'],
+                eTime: member['e_time'],
                 members: member['members'] != null?
                   (member['members'] as List<dynamic>)
                     .map((m) => ShiftMember(
@@ -75,8 +75,8 @@ class ShiftCardDataList {
           .toList():
         [],
       beforeMembers: ShiftMembers(
-        s_time: item['before_members']['s_time'],
-        e_time: item['before_members']['e_time'],
+        sTime: item['before_members']['s_time'],
+        eTime: item['before_members']['e_time'],
         members: item['before_members']['members'] != null?
           (item['before_members']['members'] as List<dynamic>)
             .map((m) => ShiftMember(
@@ -88,8 +88,8 @@ class ShiftCardDataList {
           [],
       ),
       afterMembers: ShiftMembers(
-        s_time: item['after_members']['s_time'],
-        e_time: item['after_members']['e_time'],
+        sTime: item['after_members']['s_time'],
+        eTime: item['after_members']['e_time'],
         members: item['after_members']['members'] != null?
           (item['after_members']['members'] as List<dynamic>)
             .map((m) => ShiftMember(

--- a/mobile/lib/pages/users_page.dart
+++ b/mobile/lib/pages/users_page.dart
@@ -186,9 +186,9 @@ class _UsersPageState extends State<UsersPage> {
   }
 }
 
-void _openPhoneApp(String tel_number) {
+void _openPhoneApp(String telNumber) {
   _launchURL(
-    'tel:$tel_number',
+    'tel:$telNumber',
   );
 }
 


### PR DESCRIPTION
## 概要

flutter_lints の `non_constant_identifier_names` 違反5件を解消します（親 #286 / 子 #294）。

Dart の命名規則では変数・パラメータは `lowerCamelCase` が標準です。Python 由来のスネークケース（`s_time`, `e_time`）が混入していた箇所を統一します。

```dart
// Before
final String s_time = "09:00";
final String e_time = "17:00";

// After
final String sTime = "09:00";
final String eTime = "17:00";
```

## 変更内容

1件は `fvm dart fix --apply --code=non_constant_identifier_names` で自動修正、残り4件は手動修正しました。挙動の変更はありません。

```text
mobile/lib/models/shift_card.dart  4件
mobile/lib/pages/users_page.dart   1件
```

## 確認

```bash
fvm flutter analyze 2>&1 | grep "non_constant_identifier_names" | tee /dev/stderr | wc -l | xargs -I{} sh -c 'if [ "{}" = "0" ]; then echo "OK: non_constant_identifier_names 0件"; else echo "NG: {}件残っています"; fi'
```

`non_constant_identifier_names` が0件になることを確認済み。

Closes #294