### PR TITLE
fix: print を logger に置き換え #284

### DIFF
--- a/mobile/lib/models/rescue.dart
+++ b/mobile/lib/models/rescue.dart
@@ -1,4 +1,5 @@
 // レスキュー画面のタスクのドロップダウンの選択肢として使用するデータモデル
+import 'package:seeft_mobile/configs/importer.dart';
 class RescueTaskDropdownMenuItem {
   final int id;
   final String taskName;
@@ -89,7 +90,7 @@ class TroubleRescueResponse extends RescueResponse {
 
   // factory TroubleRescueResponse.fromJson(Map<String, dynamic> json) {
   factory TroubleRescueResponse.fromJson(dynamic json) {
-    print(json);
+    logger.d(json); 
     return TroubleRescueResponse(
       id: json['id'],
       userName: json['user_name'],

--- a/mobile/lib/models/rescue.dart
+++ b/mobile/lib/models/rescue.dart
@@ -90,7 +90,7 @@ class TroubleRescueResponse extends RescueResponse {
 
   // factory TroubleRescueResponse.fromJson(Map<String, dynamic> json) {
   factory TroubleRescueResponse.fromJson(dynamic json) {
-    logger.d(json); 
+    logger.d({'id': json['id'], 'status': json['status']});
     return TroubleRescueResponse(
       id: json['id'],
       userName: json['user_name'],

--- a/mobile/lib/pages/my_shift_page.dart
+++ b/mobile/lib/pages/my_shift_page.dart
@@ -302,7 +302,7 @@ class _MyShiftPageState extends State<MyShiftPage>
   // レビューを表示する
   void _showReviewFormIfNeeded(ShiftCardDataList? shiftCardDataList, int dayID) {
     if(shiftCardDataList == null) {
-      print("シフトカードデータがありません. レビューを表示しません.");
+      logger.w("シフトカードデータがありません. レビューを表示しません.");
       return;
     }
     
@@ -331,15 +331,15 @@ class _MyShiftPageState extends State<MyShiftPage>
       // シフトカードのタスクが既にレビュー済みかどうかを確認
       final isReviewed = reviewedTaskNameBox.get(shiftCard.taskName, defaultValue: false) == true;
       if(isReviewed){
-        print("タスク「${shiftCard.taskName}」は既にレビュー済みです. レビューを表示しません。");
+        logger.d("タスク「${shiftCard.taskName}」は既にレビュー済みです. レビューを表示しません。");
         return;
       }
-      print("タスク「${shiftCard.taskName}」は未レビューです. レビューを表示します。");
+      logger.d("タスク「${shiftCard.taskName}」は未レビューです. レビューを表示します。");
       
       // シフトカードからタスクの終了時刻を取得
       final String endTime = shiftCard.endTime.padLeft(5, '0'); // 1桁時間の場合に備えて0埋め
       DateTime shiftEndTime = DateTime.parse("$targetDate $endTime");
-      print("現在時刻: $now, シフト終了時刻: $shiftEndTime");
+      logger.d("現在時刻: $now, シフト終了時刻: $shiftEndTime");
       
       // 対象のタスクが終了しているかどうかを判定
       final isFinished = now.isAfter(shiftEndTime);

--- a/mobile/lib/utils/permanent_store.dart
+++ b/mobile/lib/utils/permanent_store.dart
@@ -33,7 +33,7 @@ class PermanentStore {
       logger.d('load parmeanent store: $userID');
       return userID;
     } catch (e) {
-      print('Error while fetching SharedPreferences(getUserID): $e');
+      logger.e('Error while fetching SharedPreferences(getUserID): $e');
       return 0;
     }
   }

--- a/mobile/lib/widgets/first_jump_selector.dart
+++ b/mobile/lib/widgets/first_jump_selector.dart
@@ -24,7 +24,7 @@ class _FirstJumpSelectorState extends State<FirstJumpSelector> {
       logger.w(isUserID);
       return isUserID;
     } catch (e) {
-      print(e);
+      logger.e(e);
       return false;
     }
   }


### PR DESCRIPTION
## 概要

flutter_lints の `avoid_print` 警告7件を解消します（親 #286 / 子 #284）。

`print()` は本番環境でも常に出力されてしまいます。SeeFT では既に `package:logger` が導入されているため、用途に応じたレベルで置き換えます。

```dart
// Before
print("シフトカードデータがありません");

// After
logger.w("シフトカードデータがありません");
```

## 変更内容

`dart fix` では自動修正できないため、手動で置き換えました。文脈に応じてレベルを選択しています。

```text
mobile/lib/models/rescue.dart               JSON 確認ログ → logger.d
mobile/lib/pages/my_shift_page.dart         正常フロー確認 → logger.d / 想定外状態 → logger.w
mobile/lib/utils/permanent_store.dart       catch ブロック → logger.e
mobile/lib/widgets/first_jump_selector.dart 内容に応じて置き換え
```

## 確認

```bash
fvm flutter analyze 2>&1 | grep "avoid_print" | tee /dev/stderr | wc -l | xargs -I{} sh -c 'if [ "{}" = "0" ]; then echo "OK: avoid_print 0件"; else echo "NG: {}件残っています"; fi'
```

`avoid_print` が0件になることを確認済み。

Closes #284

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * アプリケーション全体のログ出力機構を改善しました。複数のモジュールにおいてエラーログとデバッグログの記録形式を統一し、より効率的なログ管理と問題追跡を実現しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->