### PR TITLE
fix: deprecated な url_launcher / Color / Material API を新 API に移行 #288

### DIFF
--- a/mobile/lib/pages/etc_page.dart
+++ b/mobile/lib/pages/etc_page.dart
@@ -24,8 +24,8 @@ class EtcPage extends StatelessWidget {
           logger.i("操作説明が選択されました");
           // SeeFTの操作説明のスライドを開く
           final url = seeftInstructionsUrl;
-          if (await canLaunch(url)) {
-            await launch(url);
+          if (await canLaunchUrl(Uri.parse(url))) {
+            await launchUrl(Uri.parse(url));
           } else {
             final Error error = ArgumentError('Could not launch $url');
             throw error;
@@ -40,8 +40,8 @@ class EtcPage extends StatelessWidget {
           logger.i("全体シフトが選択されました");
           // 全体シフトのURLを開く
           final url = wholeShiftUrl;
-          if (await canLaunch(url)) {
-            await launch(url);
+          if (await canLaunchUrl(Uri.parse(url))) {
+            await launchUrl(Uri.parse(url));
           } else {
             final Error error = ArgumentError('Could not launch $url');
             throw error;

--- a/mobile/lib/pages/manual_list_page.dart
+++ b/mobile/lib/pages/manual_list_page.dart
@@ -78,9 +78,10 @@ class _ManualListPageState extends State<ManualListPage> {
           ),
         ),
         onTap: () async {
-          if (await canLaunch(manuals[index]["url"].toString())) {
-            await launch((manuals[index]["url"].toString()));
+          if (await canLaunchUrl(Uri.parse(manuals[index]["url"].toString()))) {
+            await launchUrl(Uri.parse((manuals[index]["url"].toString())));
           }
+          
         },
       ),
     );

--- a/mobile/lib/pages/rescue/rescue_request_tab/tab_pages/home.dart
+++ b/mobile/lib/pages/rescue/rescue_request_tab/tab_pages/home.dart
@@ -234,8 +234,8 @@ void _openPhoneApp(String phoneNumber) async {
 
 // URLを開く関数
 Future<void> _launchURL(String url) async {
-  if (await canLaunch(url)) {
-    await launch(url);
+  if (await canLaunchUrl(Uri.parse(url))) {
+    await launchUrl(Uri.parse(url));
   } else {
     final Error error = ArgumentError('Could not launch $url');
     throw error;

--- a/mobile/lib/pages/users_page.dart
+++ b/mobile/lib/pages/users_page.dart
@@ -193,8 +193,8 @@ void _openPhoneApp(String telNumber) {
 }
 
 Future<void> _launchURL(String url) async {
-  if (await canLaunch(url)) {
-    await launch(url);
+  if (await canLaunchUrl(Uri.parse(url))) {
+     await launchUrl(Uri.parse(url));
   } else {
     final Error error = ArgumentError('Could not launch $url');
     throw error;

--- a/mobile/lib/theme/theme.dart
+++ b/mobile/lib/theme/theme.dart
@@ -345,7 +345,7 @@ class MaterialTheme {
       displayColor: colorScheme.onSurface,
     ),
     // textTheme: GoogleFonts.mPlus1pTextTheme(Theme.of(context).textTheme),  
-    scaffoldBackgroundColor: colorScheme.background,
+    scaffoldBackgroundColor: colorScheme.surface,
     canvasColor: colorScheme.surface,
     pageTransitionsTheme: const PageTransitionsTheme( // 画面遷移時のアニメーションをiOS風にする
       builders: <TargetPlatform, PageTransitionsBuilder>{

--- a/mobile/lib/widgets/custom_dropdown_menu.dart
+++ b/mobile/lib/widgets/custom_dropdown_menu.dart
@@ -26,8 +26,8 @@ class CustomDropdownMenu<T> extends StatelessWidget {
         color: AppColors.textBlack,
       ),
       menuStyle: MenuStyle(
-        backgroundColor: MaterialStatePropertyAll(AppColors.base),
-        elevation: MaterialStatePropertyAll(4),
+        backgroundColor: WidgetStatePropertyAll(AppColors.base),
+        elevation: WidgetStatePropertyAll(4),
       ),
       width: double.infinity, // 横幅を広げる
       inputDecorationTheme: InputDecorationTheme(

--- a/mobile/lib/widgets/drawer.dart
+++ b/mobile/lib/widgets/drawer.dart
@@ -30,8 +30,8 @@ class ApplicationDrawer {
           onTap: () async {
             var url =
                 "https://docs.google.com/spreadsheets/d/1KVBNRupRBFeL6Ixn9IUXzbM0wr29bpFfuaOsOeaxUQ0/edit?gid=1158066929#gid=1158066929";
-            if (await canLaunch(url)) {
-              await launch(url);
+            if (await canLaunchUrl(Uri.parse(url))) {
+              await launchUrl(Uri.parse(url));
             } else {
               final Error error = ArgumentError('Could not launch $url');
               throw error;
@@ -85,8 +85,8 @@ class ApplicationDrawer {
             var url =
             "https://docs.google.com/presentation/d/1ukPkDkkVSXWmEDY_MBOwEHPtkgm3DL64nDdLQjoTQ_0/edit#slide=id.p1";
                 //"https://docs.google.com/document/d/1zCiz6rcrQuAXdVNg15MWCun2c2Babz0umPJxfJLD-Wg";
-            if (await canLaunch(url)) {
-              await launch(url);
+            if (await canLaunchUrl(Uri.parse(url))) {
+              await launchUrl(Uri.parse(url));
             } else {
               final Error error = ArgumentError('Could not launch $url');
               throw error;

--- a/mobile/lib/widgets/rescue_dialog.dart
+++ b/mobile/lib/widgets/rescue_dialog.dart
@@ -5,7 +5,7 @@ Future<void> openRescueDialog(BuildContext context,) async {
   return showDialog<void>(
     context: context,
     barrierDismissible: false, // user must tap button!
-    barrierColor: Colors.black.withOpacity(0.5),
+    barrierColor: Colors.black.withValues(alpha: 0.5),
     builder: (BuildContext context) {
       int rescuePageIndex = 0;
       bool manualChecked = false;

--- a/mobile/lib/widgets/review_bottom_sheet.dart
+++ b/mobile/lib/widgets/review_bottom_sheet.dart
@@ -17,7 +17,7 @@ class ReviewBottomSheet {
       context: context,
       isScrollControlled: true, // 高さを自由に調整
       backgroundColor: AppColors.base,
-      barrierColor: Colors.black.withOpacity(0.2), // ← デフォルト0.54 → 薄めに調整
+      barrierColor: Colors.black.withValues(alpha: 0.2), // ← デフォルト0.54 → 薄めに調整
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
       ),

--- a/mobile/lib/widgets/shift_dialog.dart
+++ b/mobile/lib/widgets/shift_dialog.dart
@@ -11,8 +11,8 @@ getShiftDetail(workId, userId, date, weather, time) async {
 }
 
 _launchURL(url) async {
-  if (await canLaunch(url)) {
-    await launch(url);
+  if (await canLaunchUrl(Uri.parse(url))) {
+    await launchUrl(Uri.parse(url));
   } else {
     throw 'Unable to launch url $url';
   }


### PR DESCRIPTION
## 概要

flutter_lints の `deprecated_member_use` 警告21件を解消します（親 #286 / 子 #288）。

`dart fix` では自動修正できないため、すべて手動で移行しました。

## 変更内容

3種類の deprecated API を新 API に置き換えました。

**url_launcher（10箇所）**

```dart
// Before
if (await canLaunch(url)) {
  await launch(url);
}

// After
if (await canLaunchUrl(Uri.parse(url))) {
  await launchUrl(Uri.parse(url));
}
```

**withOpacity（2件）**

```dart
// Before
Colors.black.withOpacity(0.5)

// After
Colors.black.withValues(alpha: 0.5)
```

**MaterialStatePropertyAll → WidgetStatePropertyAll（2件）**

```dart
// Before
backgroundColor: MaterialStatePropertyAll(AppColors.base)

// After
backgroundColor: WidgetStatePropertyAll(AppColors.base)
```

**scaffoldBackgroundColor: colorScheme.background → surface（1件）**

Flutter 3.18 以降 `background` は廃止。後継の `surface` は同値のため表示変化なし。

```text
mobile/lib/pages/etc_page.dart                                  4件
mobile/lib/pages/manual_list_page.dart                          2件
mobile/lib/pages/rescue/rescue_request_tab/tab_pages/home.dart  2件
mobile/lib/pages/users_page.dart                                2件
mobile/lib/theme/theme.dart                                     1件
mobile/lib/widgets/custom_dropdown_menu.dart                    2件
mobile/lib/widgets/drawer.dart                                  4件
mobile/lib/widgets/rescue_dialog.dart                           1件
mobile/lib/widgets/review_bottom_sheet.dart                     1件
mobile/lib/widgets/shift_dialog.dart                            2件
```

## 確認

```bash
fvm flutter analyze 2>&1 | grep "deprecated_member_use" | tee /dev/stderr | wc -l | xargs -I{} sh -c 'if [ "{}" = "0" ]; then echo "OK: deprecated_member_use 0件"; else echo "NG: {}件残っています"; fi'
```

`deprecated_member_use` が0件になることを確認済み。

Closes #288