### PR TITLE
fix: 未使用のローカル変数を削除・コメントアウト #309

### DIFF
--- a/mobile/lib/pages/users_page.dart
+++ b/mobile/lib/pages/users_page.dart
@@ -32,7 +32,6 @@ class _UsersPageState extends State<UsersPage> {
 
   @override
   Widget build(BuildContext context) {
-    final Size size = MediaQuery.of(context).size;
     return Scaffold(
       appBar: AppBar(
         title: const Text('ユーザ一覧'),

--- a/mobile/lib/widgets/rescue_dialog.dart
+++ b/mobile/lib/widgets/rescue_dialog.dart
@@ -14,15 +14,11 @@ Future<void> openRescueDialog(BuildContext context,) async {
 
       bool taskChecked = false;
       bool locateChecked = false;
-      bool contentChecked = false;
       bool confirmError2 = false;
       TextEditingController rescueContent = TextEditingController(); 
       TextEditingController rescueNumberofPeople = TextEditingController(); 
       String? rescuePostLevel;
       String? rescuePostLeve2;
-
-      bool isChecked = false;
-
 
       return StatefulBuilder(
         builder: (context, setState){

--- a/mobile/lib/widgets/shift_dialog.dart
+++ b/mobile/lib/widgets/shift_dialog.dart
@@ -46,7 +46,7 @@ openShiftDialog(
   var resName = task["task"].toString();
   var resURL = task["url"].toString();
   var resPlace = task["place"].toString();
-  var resPresident = task["superviser"].toString();
+  // var resPresident = task["superviser"].toString();
   var resUsersNumber = res["users"].length;
   List<String> resUsersList = <String>[];
   for (var index = 0; index < resUsersNumber; index++) {


### PR DESCRIPTION
## 概要

flutter_lints の `unused_local_variable` 警告4件を解消します（親 #286 / 子 #309）。

`dart fix` では自動修正できないため、各変数の意図をコードから読み取った上で、削除またはコメントアウトを判断しました。

## 変更内容

```text
mobile/lib/pages/users_page.dart       size            画面サイズ取得後どこでも未使用 → 削除
mobile/lib/widgets/rescue_dialog.dart  contentChecked  チェックボックス状態変数だが未使用 → 削除
mobile/lib/widgets/rescue_dialog.dart  isChecked       同上、未使用 → 削除
mobile/lib/widgets/shift_dialog.dart   resPresident    代表者表示用だが表示側がコメントアウト済 → 整合のためコメントアウト
```

`shift_dialog.dart` の `resPresident` のみ削除ではなくコメントアウトしています。代表者・緊急連絡先の表示（同ファイルの ListTile）が「今回はいらないので一時的にコメントアウト」として残されているため、それと対応させ、将来表示を復活させる際にデータ取得行ごと戻せる状態を保ちました。

## 確認

```bash
fvm flutter analyze 2>&1 | grep "unused_local_variable"
```

`unused_local_variable` が0件になることを確認済み。

Closes #309

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 未使用のローカル変数宣言をコード内から削除しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->