### PR TITLE
fix: connectionState の型不一致比較を修正 #313

### DIFF
--- a/mobile/lib/pages/manual_list_page.dart
+++ b/mobile/lib/pages/manual_list_page.dart
@@ -32,8 +32,8 @@ class _ManualListPageState extends State<ManualListPage> {
       body: FutureBuilder(
         future: getData(),
         builder: (ctx, snapshot) {
-          if (snapshot.connectionState == AsyncSnapshot.waiting()) {
-            logger.w("message");
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            logger.i("Loading manual list...");
           }
           if (!snapshot.hasData) {
             // 待機画面を表示

--- a/mobile/lib/pages/users_page.dart
+++ b/mobile/lib/pages/users_page.dart
@@ -42,8 +42,8 @@ class _UsersPageState extends State<UsersPage> {
       body: FutureBuilder(
         future: getData(),
         builder: (ctx, snapshot) {
-          if (snapshot.connectionState == AsyncSnapshot.waiting()) {
-            logger.w("message");
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            logger.i("Loading user list...");
           }
           if (!snapshot.hasData) {
             // 待機画面を表示


### PR DESCRIPTION
## 概要

flutter_lints の `unrelated_type_equality_checks` 警告2件を解消します（親 #286 / 子 #313）。

このルールは「型の合わない値同士の `==` 比較」を検出します。一致しようがない比較は常に false になるため、潜在バグとして警告されます。

## 変更内容

`snapshot.connectionState`（`ConnectionState` enum）を、`AsyncSnapshot.waiting()`（`AsyncSnapshot` オブジェクトを生成するコンストラクタ）と比較していました。型が異なるため、この条件は常に false になり、中の処理は一度も実行されていませんでした。

```dart
// Before（常に false）
if (snapshot.connectionState == AsyncSnapshot.waiting()) {
  logger.w("message");
}

// After
if (snapshot.connectionState == ConnectionState.waiting) {
  logger.i("Loading manual list...");
}
```

あわせて、中身が `"message"` という意味のないプレースホルダだったログを、画面と状態がわかる内容に変更しました。ログレベルも、読み込み中は異常ではなく正常な情報のため warning から info に変更しています。

```text
mobile/lib/pages/manual_list_page.dart  "Loading manual list..."
mobile/lib/pages/users_page.dart        "Loading user list..."
```

## 確認

```bash
fvm flutter analyze 2>&1 | grep "unrelated_type_equality_checks"
```

`unrelated_type_equality_checks` が0件になることを確認済み。

## 補足

調査の過程で、この2ファイルの `FutureBuilder` がエラー状態（`hasError`）を判定しておらず、API 失敗時に待機画面のまま固まる別問題を発見しました。本 PR のスコープ外のため #346 として切り出しています。

Closes #313