### PR TITLE
fix: 初期値なし変数に型注釈を追加（#299 prefer_typing_uninitialized_variables）

### DIFF
--- a/mobile/lib/pages/users_page.dart
+++ b/mobile/lib/pages/users_page.dart
@@ -20,7 +20,7 @@ class _UsersPageState extends State<UsersPage> {
   void initState() {
     super.initState();
 
-    var bureauId;
+    List<dynamic> bureauId;
     getBureauData().then((value) async {
       bureauId = await value;
       for (int i = 0; i < bureauId.toString().length; i++) {

--- a/mobile/lib/pages/users_page.dart
+++ b/mobile/lib/pages/users_page.dart
@@ -23,9 +23,12 @@ class _UsersPageState extends State<UsersPage> {
     List<dynamic> bureauId;
     getBureauData().then((value) async {
       bureauId = await value;
-      for (int i = 0; i < bureauId.toString().length; i++) {
+      for (int i = 0; i < bureauId.length; i++) {
         bureauNameList.add(bureauId[i]["bureau"].toString());
         bureauIdList.add(bureauId[i]["id"].toString());
+      }
+      if (mounted) {
+        setState(() {});
       }
     });
   }

--- a/mobile/lib/widgets/first_jump_selector.dart
+++ b/mobile/lib/widgets/first_jump_selector.dart
@@ -39,7 +39,18 @@ class _FirstJumpSelectorState extends State<FirstJumpSelector> {
       builder: (BuildContext context, AsyncSnapshot<bool> snapshot) {
         logger.i('===============================');
         logger.i(snapshot.connectionState);
-        Widget? app;
+        // 読み込み中（waiting）のデフォルト表示。hasData / hasError 時に上書きされる
+        Widget app = MaterialApp(
+          title: constant.appName,
+          theme: materialTheme.light(),
+          darkTheme: materialTheme.dark(),
+          themeMode: ThemeMode.light,
+          home: Scaffold(
+            body: Center(
+              child: CircularProgressIndicator(color: AppColors.main),
+            ),
+          ),
+        );
         if (snapshot.hasData) {
           var isUserID = snapshot.data;
           logger.i(snapshot.connectionState);

--- a/mobile/lib/widgets/first_jump_selector.dart
+++ b/mobile/lib/widgets/first_jump_selector.dart
@@ -39,11 +39,11 @@ class _FirstJumpSelectorState extends State<FirstJumpSelector> {
       builder: (BuildContext context, AsyncSnapshot<bool> snapshot) {
         logger.i('===============================');
         logger.i(snapshot.connectionState);
-        var app;
+        Widget? app;
         if (snapshot.hasData) {
           var isUserID = snapshot.data;
           logger.i(snapshot.connectionState);
-          var homeWidget;
+          String homeWidget;
           if (isUserID!) {
             logger.i('select Layout.');
             homeWidget = '/layout';


### PR DESCRIPTION
## 概要

`prefer_typing_uninitialized_variables` lint 違反 3 件を修正。初期値なしで宣言された変数に、実際の使われ方から判断した具体的な型を付与した。型を付与した結果、これまで dynamic で隠れていた潜在バグ（ループ境界の誤り・null 返却の型エラー）が顕在化したため、併せて修正している。

closes #299
closes #348

## 変更内容

### 1. 初期値なし変数への型注釈（#299 本体）

```dart
ファイル: mobile/lib/pages/users_page.dart
- var bureauId;
+ List<dynamic> bureauId;
```

```dart
ファイル: mobile/lib/widgets/first_jump_selector.dart
- var homeWidget;
+ String homeWidget;
```

型の選定根拠:

- `bureauId` → `List<dynamic>`: `getBureauData()` が局情報の配列を返すため。`dynamic` ではなく `List` 型にすることで、要素数取得時に `.length` が使えることが型から分かる
- `homeWidget` → `String`: `'/layout'` か `'/signin'` の文字列が必ず代入される

### 2. 局データのループ境界バグと setState 抜けの修正（#348）

型を `List<dynamic>` にしたことで、ループ上限が要素数ではなく「リスト全体を文字列化した文字数」になっているバグが判明した。範囲外アクセスで `RangeError` が発生しループ後の処理に到達しないため、`setState()` 抜けと併せて同一コミットで修正する。

```dart
ファイル: mobile/lib/pages/users_page.dart
- for (int i = 0; i < bureauId.toString().length; i++) {
+ for (int i = 0; i < bureauId.length; i++) {
    bureauNameList.add(bureauId[i]["bureau"].toString());
    bureauIdList.add(bureauId[i]["id"].toString());
  }
+ if (mounted) {
+   setState(() {});
+ }
```

### 3. 起動時の待機状態で null 返却を解消

`app` を `Widget?` に型付けした結果、`return app` が `FutureBuilder` の builder 戻り値型 `Widget`（non-null）と衝突する静的解析エラー（`return_of_invalid_type_from_closure`）が顕在化した。`app` を「ローディング画面を表示する `MaterialApp`」を初期値とする non-null 宣言に変更し、型エラーの解消・waiting 時の null 返却防止・起動時のローディング表示を同時に満たす。

```dart
ファイル: mobile/lib/widgets/first_jump_selector.dart
- Widget? app;
+ Widget app = MaterialApp(
+   title: constant.appName,
+   theme: materialTheme.light(),
+   darkTheme: materialTheme.dark(),
+   themeMode: ThemeMode.light,
+   home: Scaffold(
+     body: Center(
+       child: CircularProgressIndicator(color: AppColors.main),
+     ),
+   ),
+ );
```

`FirstJumpSelector` はアプリのルート（`runApp` 直下）で `MaterialApp` を返すため、子ウィジェット用の裸の `CircularProgressIndicator` ではなく `MaterialApp` でラップしている。

## 補足

3 の `app` 初期化により、`first_jump_selector.dart` の `prefer_typing_uninitialized_variables` 違反も解消している（初期値を持つため lint 対象外になる）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * コード内の型安全性を向上させるため、変数の型指定を明示化しました。これにより、アプリケーションの安定性と保守性が改善されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->