### PR TITLE
fix: 二重のconstキーワードを削除（#301 unnecessary_const）

### DIFF
--- a/mobile/lib/pages/sign_in_page.dart
+++ b/mobile/lib/pages/sign_in_page.dart
@@ -35,7 +35,7 @@ class _SignInPageState extends State<SignInPage> {
       } else {
         setState(() {
           ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
-            content: const Text('学籍番号もしくはパスワードが違います'),
+            content: Text('学籍番号もしくはパスワードが違います'),
             backgroundColor: AppColors.error,
           ));
         });
@@ -43,7 +43,7 @@ class _SignInPageState extends State<SignInPage> {
     } catch (e) {
       setState(() {
         ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
-          content: const Text('学籍番号もしくはパスワードが違います'),
+          content: Text('学籍番号もしくはパスワードが違います'),
           backgroundColor: AppColors.error,
         ));
       });


### PR DESCRIPTION
## 概要

`unnecessary_const` lint 違反 2 件を修正。`dart fix --apply --code=unnecessary_const` で自動修正。

closes #301

## 変更内容

```
ファイル: mobile/lib/pages/sign_in_page.dart
```

外側の `const` コンストラクタのスコープ内に、さらに `const` が重複して記述されていた箇所を削除。動作変更なし。