### PR TITLE
fix: 再代入のないprivateフィールドをfinalに変更（#302 prefer_final_fields）

### DIFF
--- a/mobile/lib/utils/permanent_store.dart
+++ b/mobile/lib/utils/permanent_store.dart
@@ -15,7 +15,7 @@ late final Box reviewedTaskNameBox;
 late final Box openedCardKeysBox;
 
 class PermanentStore {
-  static PermanentStore _instance = PermanentStore();
+  static final PermanentStore _instance = PermanentStore();
 
   static getInstance() {
     return _instance;


### PR DESCRIPTION
## 概要

`prefer_final_fields` lint 違反 1 件を修正。`dart fix --apply --code=prefer_final_fields` で自動修正。

closes #302

## 変更内容

```
ファイル: mobile/lib/utils/permanent_store.dart
```

`_instance` フィールドが初期化後に再代入されていないにもかかわらず `final` 宣言がなかったため、`final` を付与。動作変更なし。