### PR TITLE
fix: dart lint バッチ修正 (#303〜#311)

### DIFF
--- a/mobile/lib/pages/my_shift_page.dart
+++ b/mobile/lib/pages/my_shift_page.dart
@@ -265,24 +265,20 @@ class _MyShiftPageState extends State<MyShiftPage>
       
       // New対象カードの検出
       Set<String> detectedNewKeys = {};
-      if (fetchedShiftCardDataList != null) {
-        final existingNewKeys = _filterAlreadyOpened(_loadPersistedNewKeys(dayID));
-        detectedNewKeys = _detectNewOrUpdatedCardKeys(
-          dayID,
-          cashedShiftCardDataList,
-          fetchedShiftCardDataList,
-        );
-        detectedNewKeys = {...existingNewKeys, ...detectedNewKeys};
-        // 既に開かれたカードを除外
-        detectedNewKeys = _filterAlreadyOpened(detectedNewKeys);
-      }
+      final existingNewKeys = _filterAlreadyOpened(_loadPersistedNewKeys(dayID));
+      detectedNewKeys = _detectNewOrUpdatedCardKeys(
+        dayID,
+        cashedShiftCardDataList,
+        fetchedShiftCardDataList,
+      );
+      detectedNewKeys = {...existingNewKeys, ...detectedNewKeys};
+       // 既に開かれたカードを除外
+      detectedNewKeys = _filterAlreadyOpened(detectedNewKeys);
       
       // hiveのキャッシュデータをフェッチデータで更新
       shiftCardBox.put('${dayID}_$weatherID', fetchedData);
       // 最新データに存在しない既読キーを掃除
-      if (fetchedShiftCardDataList != null) {
-        _cleanupStaleOpenedKeys(dayID, fetchedShiftCardDataList);
-      }
+      _cleanupStaleOpenedKeys(dayID, fetchedShiftCardDataList);
       
       // ここにレビューの処理を挟む
       _showReviewFormIfNeeded(fetchedShiftCardDataList, dayID);

--- a/mobile/lib/pages/my_shift_page.dart
+++ b/mobile/lib/pages/my_shift_page.dart
@@ -261,7 +261,7 @@ class _MyShiftPageState extends State<MyShiftPage>
       // フェッチデータが新しい場合はキャッシュデータと表示データを更新
       
       // フェッチデータをShiftCardDataListに変換
-      final ShiftCardDataList? fetchedShiftCardDataList = ShiftCardDataList.fromJson(fetchedData);
+      final ShiftCardDataList fetchedShiftCardDataList = ShiftCardDataList.fromJson(fetchedData);
       
       // New対象カードの検出
       Set<String> detectedNewKeys = {};
@@ -327,12 +327,12 @@ class _MyShiftPageState extends State<MyShiftPage>
     }
 
     // 各シフトカードに対するレビュー処理
-    shiftCardDataList.data.forEach((shiftCard) {
+    for (var shiftCard in shiftCardDataList.data) {
       // シフトカードのタスクが既にレビュー済みかどうかを確認
       final isReviewed = reviewedTaskNameBox.get(shiftCard.taskName, defaultValue: false) == true;
       if(isReviewed){
         logger.d("タスク「${shiftCard.taskName}」は既にレビュー済みです. レビューを表示しません。");
-        return;
+        continue;
       }
       logger.d("タスク「${shiftCard.taskName}」は未レビューです. レビューを表示します。");
       
@@ -351,7 +351,7 @@ class _MyShiftPageState extends State<MyShiftPage>
           _userID
         );
       }
-    });
+    }
   }
 
   // ========== New表示のためのヘルパー関数 ==========
@@ -651,7 +651,7 @@ class _MyShiftPageState extends State<MyShiftPage>
           '\n'
           'Has data: ${shiftCardDataList != null}'
         );
-        if (shiftCardDataList == null || shiftCardDataList!.data.length == 0) {
+        if (shiftCardDataList == null || shiftCardDataList!.data.isEmpty) {
           logger.i('タブ ${index + 1}: データがありません');
           // データがない場合は「データがありません」のメッセージを表示
           return Center(

--- a/mobile/lib/pages/rescue/rescue_response_tab/rescue_response_tab.dart
+++ b/mobile/lib/pages/rescue/rescue_response_tab/rescue_response_tab.dart
@@ -97,9 +97,7 @@ class _RescueResponseTabState extends State<RescueResponseTab> {
     // キャッシュからデータを取得
     final List<dynamic>? cachedData = _getCashedRescueResponses(userID);
     // キャッシュデータをList<RescueResponse>に変換
-    final List<RescueResponse>? cachedRescueResponses = cachedData != null
-        ? cachedData.map((item) => RescueResponse.fromJson(item)).toList()
-        : null;
+    final List<RescueResponse>? cachedRescueResponses = cachedData?.map((item) => RescueResponse.fromJson(item)).toList();
     
     // 表示データをキャッシュデータで更新
     setState(() {

--- a/mobile/lib/pages/wait_page.dart
+++ b/mobile/lib/pages/wait_page.dart
@@ -1,6 +1,5 @@
 import 'package:seeft_mobile/configs/importer.dart';
 
-import 'package:seeft_mobile/configs/importer.dart';
 import 'package:flutter/material.dart';
 
 class WaitPage extends StatefulWidget {

--- a/mobile/lib/widgets/shift_card.dart
+++ b/mobile/lib/widgets/shift_card.dart
@@ -153,14 +153,14 @@ class ShiftCard extends StatelessWidget {
                     title: '【担当者の一覧】',
                     content: [
                       for (var member in data.shiftMembers)
-                        '${member.s_time}〜${member.e_time}\n${member.members.map((m) => '(${m.bureau}${m.grade}) ${m.name}').join(', ')}',
+                        '${member.sTime}〜${member.eTime}\n${member.members.map((m) => '(${m.bureau}${m.grade}) ${m.name}').join(', ')}',
                     ],
                   ),
                   _buildSection(
                     title: '【前の時間の担当者の一覧】',
                     content: [
                       if (data.beforeMembers.members.isNotEmpty)
-                        '${data.beforeMembers.s_time}〜${data.beforeMembers.e_time}\n${data.beforeMembers.members.map((m) => '(${m.bureau}${m.grade}) ${m.name}').join(', ')}'
+                        '${data.beforeMembers.sTime}〜${data.beforeMembers.eTime}\n${data.beforeMembers.members.map((m) => '(${m.bureau}${m.grade}) ${m.name}').join(', ')}'
                       else
                         '前の時間の担当者はいません',
                     ],
@@ -169,7 +169,7 @@ class ShiftCard extends StatelessWidget {
                     title: '【次の時間の担当者の一覧】',
                     content: [
                       if (data.afterMembers.members.isNotEmpty)
-                        '${data.afterMembers.s_time}〜${data.afterMembers.e_time}\n${data.afterMembers.members.map((m) => '(${m.bureau}${m.grade}) ${m.name}').join(', ')}'
+                        '${data.afterMembers.sTime}〜${data.afterMembers.eTime}\n${data.afterMembers.members.map((m) => '(${m.bureau}${m.grade}) ${m.name}').join(', ')}'
                       else
                         '次の時間の担当者はいません',
                     ],

--- a/mobile/lib/widgets/shift_dialog.dart
+++ b/mobile/lib/widgets/shift_dialog.dart
@@ -7,7 +7,9 @@ getShiftDetail(workId, userId, date, weather, time) async {
     logger.w(workId);
     var res = await api.shiftDetail(workId, userId, date, weather, time);
     return res;
-  } catch (e) {}
+  } catch (e) {
+    logger.e(e);
+  }
 }
 
 _launchURL(url) async {
@@ -122,8 +124,7 @@ openShiftDialog(
                 ),
               ],
             ),
-            body: Container(
-              child: ListView(
+            body: ListView(
                 children: <Widget>[
                   ListTile(
                     leading: Icon(Icons.place_outlined),
@@ -158,7 +159,6 @@ openShiftDialog(
                   ),
                 ],
               ),
-            ),
             /*
             floatingActionButton: OutlinedButton(
               child: const Text('マニュアルへ'),

--- a/mobile/lib/widgets/shift_dialog.dart
+++ b/mobile/lib/widgets/shift_dialog.dart
@@ -9,6 +9,7 @@ getShiftDetail(workId, userId, date, weather, time) async {
     return res;
   } catch (e) {
     logger.e(e);
+    rethrow;
   }
 }
 

--- a/mobile/lib/widgets/table.dart
+++ b/mobile/lib/widgets/table.dart
@@ -82,14 +82,13 @@ class ShiftTable {
                           }
                         },
                         //child: Center(child: new Text(shifts[index]["Work"].toString())),
-                        child: Container(
-                          child: Center(
+                        child: Center(
                               child: new Text(
                                   shifts[index]["task"]["task"].toString())),
                         ),
                       ),
                     ),
-                  ))
+                  )
                 ]),
         ]);
   }


### PR DESCRIPTION
## 概要

`dart fix --apply` で自動修正できる lint ルール（#303〜#309）を1ブランチにまとめて対応する。一部は自動修正できず手動修正。

## 修正内容

```
prefer_is_empty (#303)
  my_shift_page.dart: .data.length == 0 → .data.isEmpty

unnecessary_nullable_for_final (#305)
  my_shift_page.dart: ShiftCardDataList? → ShiftCardDataList

avoid_function_literals_in_foreach_calls (#307)
  my_shift_page.dart: .forEach((shiftCard) { ... }) → for (var shiftCard in ...) { ... }
  ※ forEach 内の return が continue の意味になるため、for ループへの変換で意図を明確化

prefer_null_aware_operators (#304)
  rescue_response_tab.dart: cachedData != null ? cachedData.map(...) : null → cachedData?.map(...)

duplicate_import (#306)
  wait_page.dart: 重複していた importer.dart の import を1行削除

avoid_unnecessary_containers (#308)
  shift_dialog.dart: Container(child: ListView(...)) → ListView(...)
  table.dart: Container(child: Center(...)) → Center(...)

empty_catches (#309)
  shift_dialog.dart: } catch (e) {} → } catch (e) { logger.e(e); }

non_constant_identifier_names（手動）
  shift_card.dart: s_time / e_time → sTime / eTime（#337 の fromJson 修正に追随）
```

## 関連 issue

Close #303
Close #304
Close #305
Close #306
Close #307
Close #308
Close #309

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * シフト表示とレスキュー応答の読み込み処理を最適化しました。

* **Style**
  * フィールド命名規則を統一し、UIコンポーネント構造を簡潔にしました。

* **Chores**
  * 重複するインポートを削除し、例外処理ログを改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->