### PR TITLE
chore: golangci-lint の設定を default に切り替える

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,11 +1,6 @@
 version: "2"
 
 linters:
-  default: none
-  enable:
-    - unused
-    - revive
-    - gosec
   settings:
     revive:
       severity: warning


### PR DESCRIPTION
## Summary

- `.golangci.yml` から `default: none` と `enable:` ブロックを削除
- golangci-lint のデフォルト有効 linter（`errcheck` / `ineffassign` / `staticcheck` / `gosimple` / `govet` / `unused` など）を有効化
- `revive` / `gosec`（デフォルト外）は settings に残し引き続き有効

Close #354

## この PR 後に検出される新規指摘

この変更により CI で以下が新たに検出されるようになります。別issueで順次対応予定（親タスク: #314）。

```
errcheck:   22件
ineffassign: 3件
```

既存の #315 / #316 / #317 は引き続き有効。

## Test plan

- [ ] `cd api && golangci-lint run` でエラー数が増えることを確認（意図した変更）
- [ ] `cd api && go build ./...` でビルドが通ることを確認