### PR TITLE
fix: gosec / revive を enable に追加して再有効化する

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,9 @@
 version: "2"
 
 linters:
+  enable:
+    - gosec
+    - revive
   settings:
     revive:
       severity: warning


### PR DESCRIPTION
## Summary

#355 の default 化で `gosec` / `revive` を `linters.settings:` のみに残したが、golangci-lint v2 では `settings:` だけでは linter は有効化されない（`linters.enable:` への列挙が必要）。結果、develop で `gosec` / `revive` が実行されておらず、**#317 の SSRF（G704）が CI で検出されない**状態だった。

`enable:` に `gosec` / `revive` を追加し、標準セット（errcheck / govet / ineffassign / staticcheck / unused）へ上乗せする形で再有効化する。

Close #356

## 検出結果の変化

```text
# 修正前（develop 現状）
27 issues: errcheck 22 / ineffassign 3 / unused 2
（gosec / revive は実行されず 0）

# 修正後
29 issues: errcheck 22 / gosec 2 / ineffassign 3 / unused 2
```

復活した gosec 2件は #317 そのもの:

```text
api/lib/usecase/rescue_unified_usecase.go:299:29: G704: SSRF via taint analysis (gosec)
api/lib/usecase/rescue_unified_usecase.go:306:24: G704: SSRF via taint analysis (gosec)
```

## Test plan

- [x] `cd api && golangci-lint run` で gosec 2件（SSRF）が再検出されることを確認
- [ ] `cd api && go build ./...` でビルドが通ることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * コード品質ツールの設定を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->