### PR TITLE
fix: シフト担当者一覧が空になる問題を修正 (#353)

### DIFF
--- a/api/lib/internals/repository/shift_repository.go
+++ b/api/lib/internals/repository/shift_repository.go
@@ -61,7 +61,7 @@ func (b *shiftRepository) User(c context.Context, id string) (*sql.Rows, error) 
 
 // 特定のタスクのユーザ取得（JOINでユーザー情報も一括取得）
 func (b *shiftRepository) Users(c context.Context, task string, year string, date string, time string, weather string) (*sql.Rows, error) {
-	query := "SELECT u.id, u.name, u.mail, u.grade_id, u.department_id, u.bureau_id, u.role_id, u.student_number, u.tel, u.created_at, u.updated_at, COALECE(u.slack_user_id, '') FROM shifts s JOIN users u ON s.user_id = u.id WHERE s.task_id = $1 AND s.year_id = $2 AND s.date_id = $3 AND s.time_id = $4 AND s.weather_id = $5"
+	query := "SELECT u.id, u.name, u.mail, u.grade_id, u.department_id, u.bureau_id, u.role_id, u.student_number, u.tel, u.created_at, u.updated_at, COALESCE(u.slack_user_id, '') FROM shifts s JOIN users u ON s.user_id = u.id WHERE s.task_id = $1 AND s.year_id = $2 AND s.date_id = $3 AND s.time_id = $4 AND s.weather_id = $5"
 	rows, err := b.client.DB().QueryContext(c, query, task, year, date, time, weather)
 	if err != nil {
 		return nil, errors.Wrapf(err, "cannot connect SQL")

--- a/api/lib/internals/repository/shift_repository.go
+++ b/api/lib/internals/repository/shift_repository.go
@@ -61,7 +61,7 @@ func (b *shiftRepository) User(c context.Context, id string) (*sql.Rows, error) 
 
 // 特定のタスクのユーザ取得（JOINでユーザー情報も一括取得）
 func (b *shiftRepository) Users(c context.Context, task string, year string, date string, time string, weather string) (*sql.Rows, error) {
-	query := "SELECT u.id, u.name, u.mail, u.grade_id, u.department_id, u.bureau_id, u.role_id, u.student_number, u.tel, u.created_at, u.updated_at FROM shifts s JOIN users u ON s.user_id = u.id WHERE s.task_id = $1 AND s.year_id = $2 AND s.date_id = $3 AND s.time_id = $4 AND s.weather_id = $5"
+	query := "SELECT u.id, u.name, u.mail, u.grade_id, u.department_id, u.bureau_id, u.role_id, u.student_number, u.tel, u.created_at, u.updated_at, COALECE(u.slack_user_id, '') FROM shifts s JOIN users u ON s.user_id = u.id WHERE s.task_id = $1 AND s.year_id = $2 AND s.date_id = $3 AND s.time_id = $4 AND s.weather_id = $5"
 	rows, err := b.client.DB().QueryContext(c, query, task, year, date, time, weather)
 	if err != nil {
 		return nil, errors.Wrapf(err, "cannot connect SQL")


### PR DESCRIPTION
## 原因

`GetUsersByShift` で使われる `shift_repository.go` のクエリが 11 カラムしか返さず、`shift_usecase.go` の `Scan`（12フィールド・末尾に `SlackUserID`）と列数が一致しなかった。

`rows.Scan` は列数不一致でエラーを返す → ループ1周目で即 return → `Users` が空配列のまま返る、という流れで常に空になっていた。

```go
// shift_repository.go:64（修正前・11カラム）
"SELECT u.id, ..., u.updated_at FROM shifts s JOIN users u ON ..."

// shift_repository.go:64（修正後・12カラム）
"SELECT u.id, ..., u.updated_at, COALESCE(u.slack_user_id, '') FROM shifts s JOIN users u ON ..."
```

`slack_user_id` は NULL の行があるため、非nullable な `string` への Scan 失敗を防ぐため `COALESCE(..., '')` で空文字に変換する。

Close #353

## Test plan

- [ ] `cd api && go build ./...` でビルドが通ることを確認
- [ ] 実データでシフトカードを開き、担当者一覧が表示されることを確認