### PR TITLE
fix: usecase 層の error 握り潰しを修正 (#358)

### DIFF
--- a/api/lib/usecase/mail_auth_usecase.go
+++ b/api/lib/usecase/mail_auth_usecase.go
@@ -140,14 +140,15 @@ func (u *mailAuthUseCase) WebSignIn(c context.Context, studentNumber string, pas
 		return token, err
 	}
 
-	if err = u.sessionRep.DeleteByUserID(c, strconv.Itoa(int(user.ID))); err != nil {
-		return token, err
-	}
-
 	// パスワードがあっているか確認
 	password = strings.ReplaceAll(password, " ", "")
 	password = strings.ReplaceAll(password, "　", "")
 	if err = bcrypt.CompareHashAndPassword([]byte(user.Password), []byte(password)); err != nil {
+		return token, err
+	}
+
+	// 認証成功後に既存セッションを削除（認証前に削除すると誤パス試行で強制ログアウトできてしまう）
+	if err = u.sessionRep.DeleteByUserID(c, strconv.Itoa(int(user.ID))); err != nil {
 		return token, err
 	}
 	// トークン発行

--- a/api/lib/usecase/mail_auth_usecase.go
+++ b/api/lib/usecase/mail_auth_usecase.go
@@ -71,9 +71,17 @@ func (u *mailAuthUseCase) WebSignUp(c context.Context, name string, mail string,
 	// パスワードをハッシュ化
 	password = strings.ReplaceAll(password, " ", "")
 	password = strings.ReplaceAll(password, "　", "")
-	hashed, _ := bcrypt.GenerateFromPassword([]byte(password), 10)
-	err := u.userRep.Create(c, name, mail, gradeID, departmentID, bureauID, roleID, studentNumber, tel, string(hashed))
+	hashed, err := bcrypt.GenerateFromPassword([]byte(password), 10)
+	if err != nil {
+		return token, errors.Wrapf(err, "パスワードハッシュ化失敗")
+	}
+	if err = u.userRep.Create(c, name, mail, gradeID, departmentID, bureauID, roleID, studentNumber, tel, string(hashed)); err != nil {
+		return token, err
+	}
 	row, err := u.userRep.FindNewRecord(c)
+	if err != nil {
+		return token, err
+	}
 	err = row.Scan(
 		&user.ID,
 		&user.Name,
@@ -128,20 +136,27 @@ func (u *mailAuthUseCase) WebSignIn(c context.Context, studentNumber string, pas
 		&user.UpdatedAt,
 		&user.SlackUserID,
 	)
-	u.sessionRep.DeleteByUserID(c, strconv.Itoa(int(user.ID)))
+	if err != nil {
+		return token, err
+	}
+
+	if err = u.sessionRep.DeleteByUserID(c, strconv.Itoa(int(user.ID))); err != nil {
+		return token, err
+	}
 
 	// パスワードがあっているか確認
 	password = strings.ReplaceAll(password, " ", "")
 	password = strings.ReplaceAll(password, "　", "")
-	err = bcrypt.CompareHashAndPassword([]byte(user.Password), []byte(password))
-	if err != nil {
+	if err = bcrypt.CompareHashAndPassword([]byte(user.Password), []byte(password)); err != nil {
 		return token, err
 	}
 	// トークン発行
 	accessToken, err := _makeRandomStr(10)
-	// ログイン (セッション開始)
-	err = u.sessionRep.Create(c, strconv.Itoa(int(user.ID)), accessToken)
 	if err != nil {
+		return token, err
+	}
+	// ログイン (セッション開始)
+	if err = u.sessionRep.Create(c, strconv.Itoa(int(user.ID)), accessToken); err != nil {
 		return token, err
 	}
 	token.AccessToken = accessToken

--- a/api/lib/usecase/place_usecase.go
+++ b/api/lib/usecase/place_usecase.go
@@ -3,33 +3,33 @@ package usecase
 import (
 	"context"
 
-	rep "github.com/NUTFes/SeeFT/api/lib/internals/repository"
 	"github.com/NUTFes/SeeFT/api/lib/entity"
+	rep "github.com/NUTFes/SeeFT/api/lib/internals/repository"
 	"github.com/pkg/errors"
 )
 
 type placeUseCase struct {
-  rep rep.PlaceRepository
+	rep rep.PlaceRepository
 }
 
 type PlaceUseCase interface {
-  GetPlaces(context.Context) ([]entity.Place, error)
-  GetPlaceByID(context.Context, string) (entity.Place, error) 
+	GetPlaces(context.Context) ([]entity.Place, error)
+	GetPlaceByID(context.Context, string) (entity.Place, error)
 	CreatePlace(context.Context, string, string) (entity.Place, error)
-  UpdatePlace(context.Context, string, string, string) (entity.Place, error)
-  DeletePlace(context.Context, string) error
+	UpdatePlace(context.Context, string, string, string) (entity.Place, error)
+	DeletePlace(context.Context, string) error
 }
 
 func NewPlaceUseCase(rep rep.PlaceRepository) PlaceUseCase {
-  return &placeUseCase{rep}
+	return &placeUseCase{rep}
 }
 
 func (u *placeUseCase) GetPlaces(c context.Context) ([]entity.Place, error) {
 
-  place := entity.Place{}
-  var places []entity.Place
+	place := entity.Place{}
+	var places []entity.Place
 
-  // クエリー実行
+	// クエリー実行
 	rows, err := u.rep.All(c)
 	if err != nil {
 		return nil, err
@@ -72,8 +72,13 @@ func (u *placeUseCase) GetPlaceByID(c context.Context, id string) (entity.Place,
 
 func (u *placeUseCase) CreatePlace(c context.Context, place string, remark string) (entity.Place, error) {
 	latastPlace := entity.Place{}
-	err := u.rep.Create(c, place, remark)
+	if err := u.rep.Create(c, place, remark); err != nil {
+		return latastPlace, err
+	}
 	row, err := u.rep.FindNewRecord(c)
+	if err != nil {
+		return latastPlace, err
+	}
 	err = row.Scan(
 		&latastPlace.ID,
 		&latastPlace.Place,
@@ -103,8 +108,13 @@ func (u *placeUseCase) UpdatePlace(c context.Context, id string, placeName strin
 		return place, err
 	}
 
-	u.rep.Update(c, id, placeName, remark)
+	if err = u.rep.Update(c, id, placeName, remark); err != nil {
+		return place, err
+	}
 	row, err = u.rep.Find(c, id)
+	if err != nil {
+		return updatedPlace, err
+	}
 	err = row.Scan(
 		&updatedPlace.ID,
 		&updatedPlace.Place,

--- a/api/lib/usecase/shift_usecase.go
+++ b/api/lib/usecase/shift_usecase.go
@@ -685,7 +685,9 @@ func (u *shiftUseCase) UpdateShiftAdmin(c context.Context, id string, taskID str
 		return shift, err
 	}
 
-	u.rep.Update(c, id, taskID, userID, yearID, dateID, timeID, weatherID, isAttendance)
+	if err = u.rep.Update(c, id, taskID, userID, yearID, dateID, timeID, weatherID, isAttendance); err != nil {
+		return updatedShift, err
+	}
 	row, err = u.rep.Find(c, id)
 	err = row.Scan(
 		&updatedShift.ID,
@@ -723,7 +725,9 @@ func (u *shiftUseCase) DeleteShiftAdmin(c context.Context, id string) error {
 			"deleted_task": taskName,
 		}
 		if u.actionLogRepo != nil {
-			u.actionLogRepo.Create(c, shift.ID, shift.UserID, shift.DateID, "DELETE", diffPayload)
+			if logErr := u.actionLogRepo.Create(c, shift.ID, shift.UserID, shift.DateID, "DELETE", diffPayload); logErr != nil {
+				log.Printf("action_log記録失敗(DELETE): %v", logErr)
+			}
 		}
 	}
 
@@ -1348,25 +1352,25 @@ func (u *shiftUseCase) UpdateShiftsFromGAS(ctx context.Context, req entity.Shift
 	// N+1問題対策: 事前に必要なユーザー名とタスク名を収集
 	userNameSet := make(map[string]bool)
 	taskNameSet := make(map[string]bool)
-	
+
 	for _, change := range req.Changes {
 		userNameSet[change.UserName] = true
 		taskName := strings.ReplaceAll(change.TaskName, "　", " ")
 		taskNameSet[taskName] = true
 	}
-	
+
 	// ユーザー名のリストを作成
 	userNames := make([]string, 0, len(userNameSet))
 	for name := range userNameSet {
 		userNames = append(userNames, name)
 	}
-	
+
 	// タスク名のリストを作成
 	taskNames := make([]string, 0, len(taskNameSet))
 	for name := range taskNameSet {
 		taskNames = append(taskNames, name)
 	}
-	
+
 	// 一括でユーザーを取得してマップ化
 	userMap := make(map[string]entity.User)
 	if len(userNames) > 0 {
@@ -1375,7 +1379,7 @@ func (u *shiftUseCase) UpdateShiftsFromGAS(ctx context.Context, req entity.Shift
 			return errors.Wrap(err, "ユーザー一括取得失敗")
 		}
 		defer userRows.Close()
-		
+
 		for userRows.Next() {
 			var user entity.User
 			var slackUserID sql.NullString
@@ -1388,7 +1392,7 @@ func (u *shiftUseCase) UpdateShiftsFromGAS(ctx context.Context, req entity.Shift
 			userMap[user.Name] = user
 		}
 	}
-	
+
 	// 一括でタスクを取得してマップ化
 	taskMap := make(map[string]entity.Task)
 	if len(taskNames) > 0 {
@@ -1397,7 +1401,7 @@ func (u *shiftUseCase) UpdateShiftsFromGAS(ctx context.Context, req entity.Shift
 			return errors.Wrap(err, "タスク一括取得失敗")
 		}
 		defer taskRows.Close()
-		
+
 		for taskRows.Next() {
 			var task entity.Task
 			if err := taskRows.Scan(&task.ID, &task.Task, &task.PlaceID, &task.Url, &task.BureauID, &task.MaxMember, &task.Color, &task.Remark, &task.YearID, &task.CreatedAt, &task.UpdatedAt); err != nil {
@@ -1481,13 +1485,22 @@ func (u *shiftUseCase) UpdateShiftsFromGAS(ctx context.Context, req entity.Shift
 		taskID := strconv.Itoa(task.ID)
 
 		// 4. 既存シフトがあるか確認
-		existRow, _ := u.rep.FindByUnique(ctx, userID, dateID, timeID, weatherID)
+		existRow, err := u.rep.FindByUnique(ctx, userID, dateID, timeID, weatherID)
+		if err != nil {
+			return errors.Wrapf(err, "シフト検索失敗: user=%s, date=%s", user.Name, dateID)
+		}
 		var existShift entity.ShiftAdmin
-		dateIDInt, _ := strconv.Atoi(dateID)
+		dateIDInt, err := strconv.Atoi(dateID)
+		if err != nil {
+			return errors.Wrapf(err, "dateIDパース失敗: %v", dateID)
+		}
 		if err := existRow.Scan(&existShift.ID, &existShift.TaskID, &existShift.UserID, &existShift.YearID, &existShift.DateID, &existShift.TimeID, &existShift.WeatherID, &existShift.IsAttendance, &existShift.CreatedAt, &existShift.UpdatedAt); err == nil && existShift.ID != 0 {
 			// 既存があれば更新（タスクが変更された場合のみaction_logに記録）
 			oldTaskID := existShift.TaskID
-			newTaskID, _ := strconv.Atoi(taskID)
+			newTaskID, err := strconv.Atoi(taskID)
+			if err != nil {
+				return errors.Wrapf(err, "taskIDパース失敗: %v", taskID)
+			}
 			if oldTaskID != newTaskID {
 				// タスクが変更された場合
 				oldTaskRow, _ := u.taskRep.Find(ctx, strconv.Itoa(oldTaskID))
@@ -1511,11 +1524,15 @@ func (u *shiftUseCase) UpdateShiftsFromGAS(ctx context.Context, req entity.Shift
 					},
 				}
 				if u.actionLogRepo != nil {
-					u.actionLogRepo.Create(ctx, existShift.ID, user.ID, dateIDInt, "UPDATE", diffPayload)
+					if logErr := u.actionLogRepo.Create(ctx, existShift.ID, user.ID, dateIDInt, "UPDATE", diffPayload); logErr != nil {
+						log.Printf("action_log記録失敗(UPDATE): %v", logErr)
+					}
 				}
 			}
 			isAttendance := false
-			u.rep.Update(ctx, strconv.Itoa(existShift.ID), taskID, userID, strconv.Itoa(existShift.YearID), dateID, timeID, weatherID, strconv.FormatBool(isAttendance))
+			if err := u.rep.Update(ctx, strconv.Itoa(existShift.ID), taskID, userID, strconv.Itoa(existShift.YearID), dateID, timeID, weatherID, strconv.FormatBool(isAttendance)); err != nil {
+				return errors.Wrapf(err, "シフト更新失敗: %v", existShift.ID)
+			}
 		} else {
 			// なければ新規作成（RETURNING idで確実にIDを取得）
 			isAttendance := false
@@ -1534,7 +1551,9 @@ func (u *shiftUseCase) UpdateShiftsFromGAS(ctx context.Context, req entity.Shift
 				},
 			}
 			if u.actionLogRepo != nil {
-				u.actionLogRepo.Create(ctx, newShiftID, user.ID, dateIDInt, "CREATE", diffPayload)
+				if logErr := u.actionLogRepo.Create(ctx, newShiftID, user.ID, dateIDInt, "CREATE", diffPayload); logErr != nil {
+					log.Printf("action_log記録失敗(CREATE): %v", logErr)
+				}
 			}
 		}
 	}

--- a/api/lib/usecase/shift_usecase.go
+++ b/api/lib/usecase/shift_usecase.go
@@ -1494,7 +1494,12 @@ func (u *shiftUseCase) UpdateShiftsFromGAS(ctx context.Context, req entity.Shift
 		if err != nil {
 			return errors.Wrapf(err, "dateIDパース失敗: %v", dateID)
 		}
-		if err := existRow.Scan(&existShift.ID, &existShift.TaskID, &existShift.UserID, &existShift.YearID, &existShift.DateID, &existShift.TimeID, &existShift.WeatherID, &existShift.IsAttendance, &existShift.CreatedAt, &existShift.UpdatedAt); err == nil && existShift.ID != 0 {
+		scanErr := existRow.Scan(&existShift.ID, &existShift.TaskID, &existShift.UserID, &existShift.YearID, &existShift.DateID, &existShift.TimeID, &existShift.WeatherID, &existShift.IsAttendance, &existShift.CreatedAt, &existShift.UpdatedAt)
+		if scanErr != nil && !errors.Is(scanErr, sql.ErrNoRows) {
+			// 未存在以外のDBエラーを新規作成へフォールバックさせない（重複生成防止）
+			return errors.Wrapf(scanErr, "シフト既存確認失敗: user=%s, date=%s", user.Name, dateID)
+		}
+		if scanErr == nil && existShift.ID != 0 {
 			// 既存があれば更新（タスクが変更された場合のみaction_logに記録）
 			oldTaskID := existShift.TaskID
 			newTaskID, err := strconv.Atoi(taskID)

--- a/api/lib/usecase/task_usecase.go
+++ b/api/lib/usecase/task_usecase.go
@@ -68,6 +68,10 @@ func (b *taskUseCase) GetTasks(c context.Context) ([]entity.Task, error) {
 func (b *taskUseCase) GetTaskByID(c context.Context, id string) (entity.Task, error) {
 	var task entity.Task
 	row, err := b.rep.Find(c, id)
+	if err != nil {
+		return task, err
+	}
+
 	err = row.Scan(
 		&task.ID,
 		&task.Task,
@@ -156,8 +160,13 @@ func (b *taskUseCase) GetTasksByUserID(c context.Context, userID string) ([]enti
 
 func (u *taskUseCase) CreateTask(c context.Context, name string, placeID string, url string, bureauID string, maxMember string, color string, remark string, yearID string) (entity.Task, error) {
 	latasTask := entity.Task{}
-	err := u.rep.Create(c, name, placeID, url, bureauID, maxMember, color, remark, yearID)
+	if err := u.rep.Create(c, name, placeID, url, bureauID, maxMember, color, remark, yearID); err != nil {
+		return latasTask, err
+	}
 	row, err := u.rep.FindNewRecord(c)
+	if err != nil {
+		return latasTask, err
+	}
 	err = row.Scan(
 		&latasTask.ID,
 		&latasTask.Task,
@@ -182,6 +191,9 @@ func (u *taskUseCase) UpdateTask(c context.Context, id string, name string, plac
 	var task entity.Task
 
 	row, err := u.rep.Find(c, id)
+	if err != nil {
+		return updatedTask, err
+	}
 	err = row.Scan(
 		&task.ID,
 		&task.Task,
@@ -199,8 +211,13 @@ func (u *taskUseCase) UpdateTask(c context.Context, id string, name string, plac
 		return task, err
 	}
 
-	u.rep.Update(c, id, name, placeID, url, bureauID, maxMember, color, remark, yearID)
+	if err = u.rep.Update(c, id, name, placeID, url, bureauID, maxMember, color, remark, yearID); err != nil {
+		return task, err
+	}
 	row, err = u.rep.Find(c, id)
+	if err != nil {
+		return updatedTask, err
+	}
 	err = row.Scan(
 		&updatedTask.ID,
 		&updatedTask.Task,
@@ -265,12 +282,17 @@ func (u *taskUseCase) UpdateTasksAndPlacesFromGAS(ctx context.Context, req entit
 			// 集合場所が空の場合はデフォルトの集合場所を設定
 			placeID = "1" // デフォルトの集合場所ID
 		} else {
-			placeRow, _ := u.placeRep.FindByName(ctx, placeName)
+			placeRow, err := u.placeRep.FindByName(ctx, placeName)
+			if err != nil {
+				return errors.Wrapf(err, "集合場所検索失敗: %v", placeName)
+			}
 			var place entity.Place
 			if err := placeRow.Scan(&place.ID, &place.Place, &place.Remark, &place.CreatedAt, &place.UpdatedAt); err == nil {
 				// 集合場所が存在する場合は更新
 				remark := ""
-				u.placeRep.Update(ctx, strconv.Itoa(place.ID), placeName, remark)
+				if err := u.placeRep.Update(ctx, strconv.Itoa(place.ID), placeName, remark); err != nil {
+					return errors.Wrapf(err, "集合場所更新失敗: %v", placeName)
+				}
 			} else if err.Error() == "sql: no rows in result set" {
 				// 集合場所が存在しない場合は新規作成
 				remark := ""
@@ -279,7 +301,10 @@ func (u *taskUseCase) UpdateTasksAndPlacesFromGAS(ctx context.Context, req entit
 					return errors.Wrapf(createErr, "集合場所新規作成失敗: %v", change.Place)
 				}
 				// 再取得
-				placeRow, _ = u.placeRep.FindByName(ctx, placeName)
+				placeRow, err = u.placeRep.FindByName(ctx, placeName)
+				if err != nil {
+					return errors.Wrapf(err, "集合場所再検索失敗: %v", placeName)
+				}
 				if err := placeRow.Scan(&place.ID, &place.Place, &place.Remark, &place.CreatedAt, &place.UpdatedAt); err != nil {
 					return errors.Wrapf(err, "集合場所再取得失敗: %v", change.Place)
 				}
@@ -293,18 +318,22 @@ func (u *taskUseCase) UpdateTasksAndPlacesFromGAS(ctx context.Context, req entit
 		taskName := strings.ReplaceAll(change.TaskName, "　", " ") // 全角スペースを半角スペースに変換
 		// taskName := strings.ReplaceAll(change.TaskName, " ", "")
 		// taskName = strings.ReplaceAll(taskName, "　", "")
-		taskRow, _ := u.rep.FindByName(ctx, taskName)
+		taskRow, err := u.rep.FindByName(ctx, taskName)
+		if err != nil {
+			return errors.Wrapf(err, "タスク検索失敗: %v", taskName)
+		}
 		var task entity.Task
 		if err := taskRow.Scan(&task.ID, &task.Task, &task.PlaceID, &task.Url, &task.BureauID, &task.MaxMember, &task.Color, &task.Remark, &task.YearID, &task.CreatedAt, &task.UpdatedAt); err == nil {
 			// タスクが存在する場合は更新
 			color := "ffffff"
 			yearID := yearID
 			remark := ""
-			u.rep.Update(ctx, strconv.Itoa(task.ID), taskName, placeID, change.Url, bureauID, strconv.Itoa(change.MaxMember), color, remark, yearID)
+			if err := u.rep.Update(ctx, strconv.Itoa(task.ID), taskName, placeID, change.Url, bureauID, strconv.Itoa(change.MaxMember), color, remark, yearID); err != nil {
+				return errors.Wrapf(err, "タスク更新失敗: %v", taskName)
+			}
 		} else if err.Error() == "sql: no rows in result set" {
 			// タスクが存在しない場合は新規作成
 			color := "ffffff"
-			yearID := yearID
 			remark := ""
 			createErr := u.rep.Create(ctx, taskName, placeID, change.Url, bureauID, strconv.Itoa(change.MaxMember), color, remark, yearID)
 			if createErr != nil {

--- a/api/lib/usecase/task_usecase.go
+++ b/api/lib/usecase/task_usecase.go
@@ -2,6 +2,7 @@ package usecase
 
 import (
 	"context"
+	"database/sql"
 	"strconv"
 	"strings"
 
@@ -293,7 +294,7 @@ func (u *taskUseCase) UpdateTasksAndPlacesFromGAS(ctx context.Context, req entit
 				if err := u.placeRep.Update(ctx, strconv.Itoa(place.ID), placeName, remark); err != nil {
 					return errors.Wrapf(err, "集合場所更新失敗: %v", placeName)
 				}
-			} else if err.Error() == "sql: no rows in result set" {
+			} else if errors.Is(err, sql.ErrNoRows) {
 				// 集合場所が存在しない場合は新規作成
 				remark := ""
 				createErr := u.placeRep.Create(ctx, placeName, remark)
@@ -331,7 +332,7 @@ func (u *taskUseCase) UpdateTasksAndPlacesFromGAS(ctx context.Context, req entit
 			if err := u.rep.Update(ctx, strconv.Itoa(task.ID), taskName, placeID, change.Url, bureauID, strconv.Itoa(change.MaxMember), color, remark, yearID); err != nil {
 				return errors.Wrapf(err, "タスク更新失敗: %v", taskName)
 			}
-		} else if err.Error() == "sql: no rows in result set" {
+		} else if errors.Is(err, sql.ErrNoRows) {
 			// タスクが存在しない場合は新規作成
 			color := "ffffff"
 			remark := ""

--- a/api/lib/usecase/user_usecase.go
+++ b/api/lib/usecase/user_usecase.go
@@ -376,7 +376,7 @@ func (u *userUseCase) UpdateUsersFromGAS(ctx context.Context, req entity.UserCha
 			if err := u.userRep.Update(ctx, strconv.Itoa(user.ID), change.Name, user.Mail, gradeID, departmentID, bureauID, strconv.Itoa(user.RoleID), studentNumber, tel, user.Password); err != nil {
 				return errors.Wrapf(err, "ユーザー更新失敗: %v", change.Name)
 			}
-		} else if err.Error() == "sql: no rows in result set" {
+		} else if errors.Is(err, sql.ErrNoRows) {
 			// ユーザーがいなければ新規作成
 			name := change.Name
 			mail := ""

--- a/api/lib/usecase/user_usecase.go
+++ b/api/lib/usecase/user_usecase.go
@@ -82,6 +82,9 @@ func (u *userUseCase) GetUserByID(c context.Context, id string) (entity.User, er
 	var slackUserID sql.NullString
 
 	row, err := u.userRep.Find(c, id)
+	if err != nil {
+		return user, err // ← ゼロ値の task を返す
+	}
 	err = row.Scan(
 		&user.ID,
 		&user.Name,
@@ -113,9 +116,17 @@ func (u *userUseCase) CreateUser(c context.Context, name string, mail string, gr
 	var slackUserID sql.NullString
 	password = strings.ReplaceAll(password, " ", "")
 	password = strings.ReplaceAll(password, "　", "")
-	hashedPassword, _ := bcrypt.GenerateFromPassword([]byte(password), 10)
-	err := u.userRep.Create(c, name, mail, gradeID, departmentID, bureauID, roleID, studentNumber, tel, string(hashedPassword))
+	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(password), 10)
+	if err != nil {
+		return latastUser, err
+	}
+	if err = u.userRep.Create(c, name, mail, gradeID, departmentID, bureauID, roleID, studentNumber, tel, string(hashedPassword)); err != nil {
+		return latastUser, err
+	}
 	row, err := u.userRep.FindNewRecord(c)
+	if err != nil {
+		return latastUser, err
+	}
 	err = row.Scan(
 		&latastUser.ID,
 		&latastUser.Name,
@@ -146,6 +157,9 @@ func (u *userUseCase) UpdateUser(c context.Context, id string, name string, mail
 	var slackUserID sql.NullString
 
 	row, err := u.userRep.Find(c, id)
+	if err != nil {
+		return user, err // ← ゼロ値の task を返す
+	}
 	err = row.Scan(
 		&user.ID,
 		&user.Name,
@@ -168,8 +182,13 @@ func (u *userUseCase) UpdateUser(c context.Context, id string, name string, mail
 		user.SlackUserID = slackUserID.String
 	}
 
-	u.userRep.Update(c, id, name, mail, gradeID, departmentID, bureauID, roleID, studentNumber, tel, user.Password)
+	if err = u.userRep.Update(c, id, name, mail, gradeID, departmentID, bureauID, roleID, studentNumber, tel, user.Password); err != nil {
+		return updatedUser, err
+	}
 	row, err = u.userRep.Find(c, id)
+	if err != nil {
+		return user, err // ← ゼロ値の task を返す
+	}
 	err = row.Scan(
 		&updatedUser.ID,
 		&updatedUser.Name,
@@ -220,6 +239,9 @@ func (u *userUseCase) GetCurrentUser(c context.Context, accessToken string) (ent
 	// userIDの該当するuserを取得
 	var slackUserID sql.NullString
 	row, err = u.userRep.Find(c, strconv.Itoa(session.UserID))
+	if err != nil {
+		return user, err // ← ゼロ値の task を返す
+	}
 	err = row.Scan(
 		&user.ID,
 		&user.Name,
@@ -340,7 +362,10 @@ func (u *userUseCase) UpdateUsersFromGAS(ctx context.Context, req entity.UserCha
 		// ユーザー名からUserID取得
 		userName := strings.ReplaceAll(change.Name, " ", "")
 		userName = strings.ReplaceAll(userName, "　", "")
-		userRow, _ := u.userRep.FindByName(ctx, userName) // Rowはユーザー名が入っている前提
+		userRow, err := u.userRep.FindByName(ctx, userName)
+		if err != nil {
+			return errors.Wrapf(err, "ユーザー検索失敗: %v", userName)
+		}
 		var user entity.User
 		var slackUserID sql.NullString
 		if err := userRow.Scan(&user.ID, &user.Name, &user.Mail, &user.GradeID, &user.DepartmentID, &user.BureauID, &user.RoleID, &user.StudentNumber, &user.Tel, &user.Password, &user.CreatedAt, &user.UpdatedAt, &slackUserID); err == nil {
@@ -348,20 +373,28 @@ func (u *userUseCase) UpdateUsersFromGAS(ctx context.Context, req entity.UserCha
 				user.SlackUserID = slackUserID.String
 			}
 			// ユーザーが存在すれば更新
-			u.userRep.Update(ctx, strconv.Itoa(user.ID), change.Name, user.Mail, gradeID, departmentID, bureauID, strconv.Itoa(user.RoleID), studentNumber, tel, user.Password)
+			if err := u.userRep.Update(ctx, strconv.Itoa(user.ID), change.Name, user.Mail, gradeID, departmentID, bureauID, strconv.Itoa(user.RoleID), studentNumber, tel, user.Password); err != nil {
+				return errors.Wrapf(err, "ユーザー更新失敗: %v", change.Name)
+			}
 		} else if err.Error() == "sql: no rows in result set" {
 			// ユーザーがいなければ新規作成
 			name := change.Name
 			mail := ""
 			roleID := "1"
 			password := userDefaultPassword
-			hashed, _ := bcrypt.GenerateFromPassword([]byte(password), 10)
+			hashed, err := bcrypt.GenerateFromPassword([]byte(password), 10)
+			if err != nil {
+				return errors.Wrapf(err, "パスワードハッシュ化失敗: %v", change.Name)
+			}
 			createErr := u.userRep.Create(ctx, name, mail, gradeID, departmentID, bureauID, roleID, studentNumber, tel, string(hashed))
 			if createErr != nil {
 				return errors.Wrapf(createErr, "ユーザー新規作成失敗: %v", change.Name)
 			}
 			// 再取得
-			userRow, _ = u.userRep.FindByName(ctx, change.Name)
+			userRow, err = u.userRep.FindByName(ctx, change.Name)
+			if err != nil {
+				return errors.Wrapf(err, "ユーザー再検索失敗: %v", change.Name)
+			}
 			if err := userRow.Scan(&user.ID, &user.Name, &user.Mail, &user.GradeID, &user.DepartmentID, &user.BureauID, &user.RoleID, &user.StudentNumber, &user.Tel, &user.Password, &user.CreatedAt, &user.UpdatedAt, &slackUserID); err != nil {
 				return errors.Wrapf(err, "ユーザー再取得失敗: %v", change.Name)
 			}


### PR DESCRIPTION
## Summary

errcheck で検出された usecase 層の **write 系メソッド(Update/Create/Destroy)の戻り値 error 握り潰し**を解消（#358）。あわせて同5ファイル内の関連する error ハンドリングの綻び（bcrypt 失敗・strconv パースエラー喪失・Create/Update 後の err 上書き）も整理した。

Close #358

## 変更内容

| ファイル | 主な修正 |
|---|---|
| shift_usecase.go | `UpdateShiftAdmin`/`UpdateShiftsFromGAS` の `Update` を error 処理。`action_log` の `Create` は best-effort のため **log-and-continue**（メイン処理は中断しない）。`dateID`/`taskID` のパースエラーを伝播 |
| mail_auth_usecase.go | `WebSignUp`/`WebSignIn` の `bcrypt`・`Create`・`_makeRandomStr`・`sessionRep.Create` の err チェック追加（`_makeRandomStr` の err 上書きバグを解消） |
| place/task/user_usecase.go | `Create`/`Update`・`FindNewRecord` の戻り値 err チェック追加 |

新規メッセージは既存の日本語規約 `errors.Wrapf(err, "〜失敗: %v")` に統一。既存の英語メッセージ（`cannot connect SQL` 等）は不変。

## errcheck の変化

```
修正前: 22 件
修正後: 12 件（#358 の write 系 10 件すべて解消）
```

残 12 件はすべてスコープ外（別issue）:
- defer Close 9 件 → #359
- `e.Start` / `c.JSON` 3 件 → #316

## スコープ外（別途対応）

- `defer X.Close()` のエラー処理 → #359
- bureau/department/grade の ineffassign → #360
- user_usecase の unused フィールド → #315
- error を返せない純粋関数内の `strconv.Atoi`（shift 870/951-954）→ 別issue予定
- repository の文字列連結 SQL（インジェクション余地）→ 別issue予定

## Test plan

- [x] `cd api && go build ./...` が通る
- [x] `cd api && golangci-lint run` で write 系 errcheck が 0（残は #359/#316 のみ）
- [ ] shift 更新/削除系 API で action_log 失敗時もメイン処理が継続することを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * ユーザー認証処理におけるエラーハンドリングを強化し、パスワードハッシュ生成失敗時の処理をより確実に実行するよう改善しました。
  * データ作成・更新処理全般において、エラー発生時に確実に処理を停止し、不正な状態でのデータ操作を防止するようにしました。
  * 各リポジトリ呼び出し時のエラー検出精度を向上させ、システム全体の信頼性を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->