### PR TITLE
fix: defer X.Close() のerrcheck指摘を解消 (#359)

### DIFF
--- a/api/lib/externals/db/db.go
+++ b/api/lib/externals/db/db.go
@@ -67,7 +67,7 @@ func ConnectMySQL() (client, error) {
 
 func (c client) CloseDB() {
 	if c.db != nil {
-		c.db.Close()
+		_ = c.db.Close()
 	}
 }
 

--- a/api/lib/usecase/bureau_usecase.go
+++ b/api/lib/usecase/bureau_usecase.go
@@ -31,7 +31,7 @@ func (a *bureauUseCase) GetBureaus(c context.Context) ([]entity.Bureau, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	for rows.Next() {
 		err := rows.Scan(

--- a/api/lib/usecase/department_usecase.go
+++ b/api/lib/usecase/department_usecase.go
@@ -31,7 +31,7 @@ func (u *departmentUseCase) GetDepartments(c context.Context) ([]entity.Departme
 	  if err != nil {
 		  return nil, err
 	  }
-	  defer rows.Close()
+	  defer func() { _ = rows.Close() }()
 
 	  for rows.Next() {
 		  err := rows.Scan(

--- a/api/lib/usecase/grade_usecase.go
+++ b/api/lib/usecase/grade_usecase.go
@@ -31,7 +31,7 @@ func (u *gradeUseCase) GetGrades(c context.Context) ([]entity.Grade, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	for rows.Next() {
 		err := rows.Scan(

--- a/api/lib/usecase/notification_usecase.go
+++ b/api/lib/usecase/notification_usecase.go
@@ -60,7 +60,7 @@ func (n *notificationUseCase) ProcessUnsentNotifications(ctx context.Context) er
 	if err != nil {
 		return errors.Wrapf(err, "failed to get unsent logs")
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	// 2. ログを読み込んでエンティティに変換
 	var logs []entity.ActionLog
@@ -212,7 +212,7 @@ func (n *notificationUseCase) loadTimeMap(ctx context.Context) (map[int]entity.T
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get all times")
 	}
-	defer timeRow.Close()
+	defer func() { _ = timeRow.Close() }()
 
 	for timeRow.Next() {
 		var time entity.Time

--- a/api/lib/usecase/place_usecase.go
+++ b/api/lib/usecase/place_usecase.go
@@ -34,7 +34,7 @@ func (u *placeUseCase) GetPlaces(c context.Context) ([]entity.Place, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	for rows.Next() {
 		err := rows.Scan(

--- a/api/lib/usecase/question_rescue_usecase.go
+++ b/api/lib/usecase/question_rescue_usecase.go
@@ -33,7 +33,7 @@ func (qu *questionRescueUseCase) GetQuestionRescues(c context.Context) ([]entity
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get question rescues")
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var questionRescues []entity.QuestionRescueForGet
 	for rows.Next() {
@@ -72,7 +72,7 @@ func (qu *questionRescueUseCase) GetQuestionRescuesByUserID(c context.Context, u
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get question rescues by user ID")
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var questionRescues []entity.QuestionRescueForGet
 	for rows.Next() {

--- a/api/lib/usecase/rescue_unified_usecase.go
+++ b/api/lib/usecase/rescue_unified_usecase.go
@@ -119,7 +119,7 @@ func (ru *rescueUnifiedUseCase) getQuestionRescues(c context.Context, userID str
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var rescues []entity.RescueResponse
 	for rows.Next() {
@@ -156,7 +156,7 @@ func (ru *rescueUnifiedUseCase) getShorthandedRescues(c context.Context, userID 
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var rescues []entity.RescueResponse
 	for rows.Next() {
@@ -200,7 +200,7 @@ func (ru *rescueUnifiedUseCase) getTroubleRescues(c context.Context, userID stri
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var rescues []entity.RescueResponse
 	for rows.Next() {
@@ -307,7 +307,7 @@ func (ru *rescueUnifiedUseCase) SendRescueToGAS(data map[string]interface{}) err
 	if err != nil {
 		return errors.Wrap(err, "GASへの送信失敗")
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return errors.Errorf("GASが非OKステータスを返しました: %d", resp.StatusCode)

--- a/api/lib/usecase/review_usecase.go
+++ b/api/lib/usecase/review_usecase.go
@@ -34,7 +34,7 @@ func (u *reviewUseCase) GetReviewsGAS(ctx context.Context) ([]entity.ReviewGAS, 
 	if err != nil {
 		return nil, errors.Wrap(err, "reviewRep.AllWithDetails")
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var res []entity.ReviewGAS
 	for rows.Next() {

--- a/api/lib/usecase/shift_usecase.go
+++ b/api/lib/usecase/shift_usecase.go
@@ -87,7 +87,7 @@ func (a *shiftUseCase) GetShifts(c context.Context) ([]entity.Shift, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	for rows.Next() {
 		err := rows.Scan(
@@ -297,7 +297,7 @@ func (a *shiftUseCase) GetShiftsByUser(c context.Context, id string) ([]entity.S
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	for rows.Next() {
 		err := rows.Scan(
@@ -409,7 +409,7 @@ func (a *shiftUseCase) GetShiftsByUserAndDateAndWeather(c context.Context, id st
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	for rows.Next() {
 		err := rows.Scan(
@@ -520,7 +520,7 @@ func (a *shiftUseCase) GetUsersByShift(c context.Context, task string, year stri
 	if err != nil {
 		return shiftUsers, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	for rows.Next() {
 		// JOINで取得したユーザー情報を直接Scan（個別SQLは不要、passwordは取得しない）
@@ -596,7 +596,7 @@ func (a *shiftUseCase) GetShiftsAdmin(c context.Context) ([]entity.ShiftAdmin, e
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	for rows.Next() {
 		err := rows.Scan(
@@ -744,7 +744,7 @@ func (a *shiftUseCase) GetShiftsAdminByDateAndWeather(c context.Context, date st
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	for rows.Next() {
 		err := rows.Scan(
@@ -777,7 +777,7 @@ func (a *shiftUseCase) GetShiftsAdminByDateAndWeatherAndTime(c context.Context, 
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	for rows.Next() {
 		err := rows.Scan(
@@ -1336,7 +1336,7 @@ func (u *shiftUseCase) SendToGAS(ctx context.Context, req entity.ShiftRequest) e
 		log.Printf("failed to send request to GAS: %v", err)
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		log.Printf("GAS returned non-OK status: %d", resp.StatusCode)
@@ -1378,7 +1378,7 @@ func (u *shiftUseCase) UpdateShiftsFromGAS(ctx context.Context, req entity.Shift
 		if err != nil {
 			return errors.Wrap(err, "ユーザー一括取得失敗")
 		}
-		defer userRows.Close()
+		defer func() { _ = userRows.Close() }()
 
 		for userRows.Next() {
 			var user entity.User
@@ -1400,7 +1400,7 @@ func (u *shiftUseCase) UpdateShiftsFromGAS(ctx context.Context, req entity.Shift
 		if err != nil {
 			return errors.Wrap(err, "タスク一括取得失敗")
 		}
-		defer taskRows.Close()
+		defer func() { _ = taskRows.Close() }()
 
 		for taskRows.Next() {
 			var task entity.Task
@@ -1572,7 +1572,7 @@ func (a *shiftUseCase) loadGradeMap(ctx context.Context) (map[int]string, error)
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	for rows.Next() {
 		var grade entity.Grade
@@ -1591,7 +1591,7 @@ func (a *shiftUseCase) loadBureauMap(ctx context.Context) (map[int]string, error
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	for rows.Next() {
 		var bureau entity.Bureau

--- a/api/lib/usecase/shorthanded_rescue_usecase.go
+++ b/api/lib/usecase/shorthanded_rescue_usecase.go
@@ -34,7 +34,7 @@ func (su *shorthandedRescueUseCase) GetShorthandedRescues(c context.Context) ([]
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get shorthanded rescues")
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var shorthandedRescues []entity.ShorthandedRescueForGet
 	for rows.Next() {
@@ -75,7 +75,7 @@ func (su *shorthandedRescueUseCase) GetShorthandedRescuesByUserID(c context.Cont
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get shorthanded rescues by user ID")
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var shorthandedRescues []entity.ShorthandedRescueForGet
 	for rows.Next() {
@@ -98,7 +98,7 @@ func (su *shorthandedRescueUseCase) GetShorthandedRescuesByTaskID(c context.Cont
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get shorthanded rescues by task ID")
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var shorthandedRescues []entity.ShorthandedRescueForGet
 	for rows.Next() {

--- a/api/lib/usecase/task_usecase.go
+++ b/api/lib/usecase/task_usecase.go
@@ -41,7 +41,7 @@ func (b *taskUseCase) GetTasks(c context.Context) ([]entity.Task, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	for rows.Next() {
 		err := rows.Scan(
@@ -101,7 +101,7 @@ func (b *taskUseCase) GetTasksByShift(c context.Context, shift string) ([]entity
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	for rows.Next() {
 		err := rows.Scan(
@@ -134,7 +134,7 @@ func (b *taskUseCase) GetTasksByUserID(c context.Context, userID string) ([]enti
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	for rows.Next() {
 		err := rows.Scan(

--- a/api/lib/usecase/time_usecase.go
+++ b/api/lib/usecase/time_usecase.go
@@ -29,7 +29,7 @@ func (b *timeUseCase) GetTimes(c context.Context) ([]entity.Time, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	for rows.Next() {
 		err := rows.Scan(

--- a/api/lib/usecase/trouble_rescue_usecase.go
+++ b/api/lib/usecase/trouble_rescue_usecase.go
@@ -34,7 +34,7 @@ func (tu *troubleRescueUseCase) GetTroubleRescues(c context.Context) ([]entity.T
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get trouble rescues")
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var troubleRescues []entity.TroubleRescueForGet
 	for rows.Next() {
@@ -75,7 +75,7 @@ func (tu *troubleRescueUseCase) GetTroubleRescuesByUserID(c context.Context, use
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get trouble rescues by user ID")
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var troubleRescues []entity.TroubleRescueForGet
 	for rows.Next() {
@@ -98,7 +98,7 @@ func (tu *troubleRescueUseCase) GetTroubleRescuesByTaskID(c context.Context, tas
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get trouble rescues by task ID")
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var troubleRescues []entity.TroubleRescueForGet
 	for rows.Next() {

--- a/api/lib/usecase/user_usecase.go
+++ b/api/lib/usecase/user_usecase.go
@@ -43,7 +43,7 @@ func (u *userUseCase) GetUsers(c context.Context) ([]entity.User, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	for rows.Next() {
 		var slackUserID sql.NullString


### PR DESCRIPTION
## Summary

`defer rows.Close()` 等の戻り値エラー無視（errcheck）を、`defer func() { _ = X.Close() }()` の形で明示無視に統一する。Close 呼び出し自体は維持し、無害なエラー報告のみ明示的に破棄する。

Close #359

## スコープが「9件」ではなく「37件」だった

golangci-lint の既定 `max-same-issues:3` により、同一メッセージ（`Error return value of rows.Close is not checked`）が capped 表示され、**12件中9件しか見えていなかった**。`--max-same-issues=0` で確認すると defer Close 系は **37件**。本PRはその全件を解消する。

> 表示キャップ自体は #371（max-same-issues: 0）で develop に解消済み。

## 対象（15ファイル / 37箇所）

```text
defer rows.Close()       … usecase 各所（大半）
defer timeRow.Close()    … notification
defer resp.Body.Close()  … rescue / shift
defer userRows.Close() / taskRows.Close() … shift
c.db.Close()（直接呼び出し）… externals/db/db.go CloseDB()
```

## 変更方針

- 一律 `_ =` で明示無視（クエリ結果・HTTPボディ・最終DBクローズのエラーは実用上アクション不能）
- 各 Close 行のみ変更。gofmt の全体再整形はしない（差分を Close 行に限定）
- 新規 import なし

## 結果

```text
errcheck の Close 系: 37 → 0
```

残る errcheck 3件（server.go e.Start / user_controller.go c.JSON ×2）は #316 の管轄。

## Test plan

- [x] `cd api && go build ./...` 通過
- [x] `golangci-lint run --max-same-issues=0` で Close 系 errcheck が 0
- [x] 差分は Close 行のみ（過剰修正・再整形なし）
- [x] develop（#362/#366/#368/#371 マージ済み）取り込み後もビルド・Close errcheck 0 を確認（#368 の ineffassign 修正と別行で共存）