### PR TITLE
fix: ineffassign（単発 Find→Scan）を解消 (#360)

### DIFF
--- a/api/lib/usecase/bureau_usecase.go
+++ b/api/lib/usecase/bureau_usecase.go
@@ -54,6 +54,9 @@ func (a *bureauUseCase) GetBureaus(c context.Context) ([]entity.Bureau, error) {
 func (b *bureauUseCase) GetBureauByID(c context.Context, id string) (entity.Bureau, error) {
 	var bureau entity.Bureau
 	row, err := b.rep.Find(c, id)
+	if err != nil {
+		return bureau, err
+	}
 	err = row.Scan(
 		&bureau.ID,
 		&bureau.Bureau,

--- a/api/lib/usecase/department_usecase.go
+++ b/api/lib/usecase/department_usecase.go
@@ -53,6 +53,9 @@ func (u *departmentUseCase) GetDepartments(c context.Context) ([]entity.Departme
 func (u *departmentUseCase) GetDepartmentByID(c context.Context, id string)(entity.Department, error){
 	var department entity.Department
 	row, err := u.rep.Find(c, id)
+	if err != nil {
+		return department, err
+	}
 	err = row.Scan(
 		&department.ID,
 		&department.Department,

--- a/api/lib/usecase/grade_usecase.go
+++ b/api/lib/usecase/grade_usecase.go
@@ -53,6 +53,9 @@ func (u *gradeUseCase) GetGrades(c context.Context) ([]entity.Grade, error) {
 func (u *gradeUseCase) GetGradeByID(c context.Context, id string) (entity.Grade, error) {
 	var grade entity.Grade
 	row, err := u.rep.Find(c, id)
+	if err != nil {
+		return grade, err
+	}
 	err = row.Scan(
 		&grade.ID,
 		&grade.Grade,

--- a/api/lib/usecase/place_usecase.go
+++ b/api/lib/usecase/place_usecase.go
@@ -57,6 +57,9 @@ func (u *placeUseCase) GetPlaces(c context.Context) ([]entity.Place, error) {
 func (u *placeUseCase) GetPlaceByID(c context.Context, id string) (entity.Place, error) {
 	var place entity.Place
 	row, err := u.rep.Find(c, id)
+	if err != nil {
+		return place, err
+	}
 	err = row.Scan(
 		&place.ID,
 		&place.Place,
@@ -97,6 +100,9 @@ func (u *placeUseCase) UpdatePlace(c context.Context, id string, placeName strin
 	var place entity.Place
 
 	row, err := u.rep.Find(c, id)
+	if err != nil {
+		return place, err
+	}
 	err = row.Scan(
 		&place.ID,
 		&place.Place,

--- a/api/lib/usecase/time_usecase.go
+++ b/api/lib/usecase/time_usecase.go
@@ -51,6 +51,9 @@ func (b *timeUseCase) GetTimes(c context.Context) ([]entity.Time, error) {
 func (b *timeUseCase) GetTimeByID(c context.Context, id string) (entity.Time, error) {
 	var time entity.Time
 	row, err := b.rep.Find(c, id)
+	if err != nil {
+		return time, err
+	}
 	err = row.Scan(
 		&time.ID,
 		&time.Time,


### PR DESCRIPTION
## Summary

`GetByID` / `UpdatePlace` 系で `row, err := Find(c, id)` の `err` が直後の `row.Scan(...)` で上書きされ ineffectual になっていた **6箇所**（bureau / department / grade / place×2 / time）に、Find 直後の `if err != nil` チェックを挿入する。

repository の `Find` は実装上常に `nil` を返すため、挿入は **no-op で挙動は変わらない**。ineffassign を黙らせ整合性を上げるのが目的。

Refs #360

## max-same-issues の罠（重要）

`ineffassign` は golangci-lint 既定の `max-same-issues:3` で **capped 表示3件**だが、`--max-same-issues=0 --max-issues-per-linter=0` で見ると **実際は76件**ある（#359 の defer Close が「9→37」だったのと同じ）。

本PRは**挙動不変で安全な単発パターン6件のみ**を対象とする。

## スコープ外（別対応）

- **`shift_usecase.go` の連鎖 Find→Scan 約60件** → 別issue。1関数で5〜10回 Find→Scan が連鎖し中間エラーを握り潰しており、機械修正すると挙動が変わる。ヘルパー関数化・グローバル変数の廃止・疑わしいバグ（`rows.Scan` vs `row.Scan`）調査を伴うリファクタ。
- **`mail_auth_usecase.go` SignIn (:38)** → 除外。`FindByStudentNumber→Scan` の Scan エラーを表面化させると「ユーザー不在」と「パスワード誤り」を区別して返す＝**ユーザー列挙の側チャネル**になりうる。要セキュリティ判断。

## 結果

```text
ineffassign: 76 → 70（本PRで6件解消）
対象5ファイル(bureau/department/grade/place/time): ineffassign 0
```

## Test plan

- [x] `cd api && go build ./...` 通過
- [x] `golangci-lint run --max-same-issues=0` で対象5ファイルの ineffassign が 0
- [x] 差分は Find 直後の if err チェック挿入のみ（過剰修正・再整形なし）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * 複数の機能においてエラーハンドリングを改善しました。リポジトリからのデータ取得失敗時に、より適切なエラー処理が実行されるようになり、APIの安定性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->