### PR TITLE
chore: golangci-lint の max-same-issues を 0 にして真の件数を可視化

### DIFF
--- a/api/.golangci.yml
+++ b/api/.golangci.yml
@@ -7,7 +7,11 @@ linters:
   settings:
     revive:
       severity: warning
-    gosec:
+    gosec: {}
+
+issues:
+  max-same-issues: 0
+  max-issues-per-linter: 0
 
 run:
   timeout: 5m


### PR DESCRIPTION
## Summary

golangci-lint の既定 `max-same-issues:3` / `max-issues-per-linter:50` で同一指摘が cap され、lint cleanup で実件数を二度取り違えた（errcheck Close は 9→37 件 / ineffassign は 3→76 件）。両キャップを 0 にして真の件数を可視化する。

```yaml
issues:
  max-same-issues: 0
  max-issues-per-linter: 0
```

あわせて `gosec:`（null）→ `gosec: {}` に変更し `golangci-lint config verify` も通るようにする（`run` の挙動は同一）。

Close #370

## 影響

- `.github/workflows` は無く、golangci-lint をブロッキング実行する CI は無い → 他PRをブロックしない
- CodeRabbit / ローカルで隠れていた件数が全部見える（cleanup 完了まで表示増＝想定通り）

## Test plan

- [x] `golangci-lint config verify` が通る（gosec: {} 化）
- [x] `golangci-lint run` が uncapped で全件表示