### PR TITLE
fix: errcheck（e.Start / c.JSON）を解消 (#316)

### DIFF
--- a/api/lib/externals/server/server.go
+++ b/api/lib/externals/server/server.go
@@ -1,13 +1,14 @@
 package server
 
 import (
+	"net/http"
+	"os"
+
 	_ "github.com/NUTFes/SeeFT/api/docs"
 	"github.com/NUTFes/SeeFT/api/lib/router"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 	echoSwagger "github.com/swaggo/echo-swagger"
-	"net/http"
-	"os"
 )
 
 func RunServer(router router.Router) {
@@ -39,5 +40,5 @@ func RunServer(router router.Router) {
 	e.GET("/swagger/*", echoSwagger.WrapHandler)
 
 	// サーバー起動
-	e.Start(":1234")
+	e.Logger.Fatal(e.Start(":1234"))
 }

--- a/api/lib/internals/controller/user_controller.go
+++ b/api/lib/internals/controller/user_controller.go
@@ -97,11 +97,9 @@ func (auth *userController) GetCurrentUser(c echo.Context) error {
 	accessToken := c.Request().Header["Access-Token"][0]
 	user, err := auth.u.GetCurrentUser(c.Request().Context(), accessToken)
 	if err != nil {
-		c.JSON(http.StatusNotFound, user)
-		return err
+		return c.JSON(http.StatusNotFound, user)
 	} else {
-		c.JSON(http.StatusOK, user)
-		return nil
+		return c.JSON(http.StatusOK, user)
 	}
 }
 


### PR DESCRIPTION
## Summary

errcheck が指摘していた3件（`e.Start` 1件 + `c.JSON` 2件）を解消する。これで **errcheck は全体で 0 件**（#358 / #359 と合わせて errcheck 完了）。

Close #316

## 変更

**server.go: サーバー起動エラーの処理**
```go
// Before
e.Start(":1234")
// After
e.Logger.Fatal(e.Start(":1234"))
```
起動失敗（ポート競合など）は致命的なので、ログを出してプロセス終了する Echo の定石に統一。

**user_controller.go GetCurrentUser: レスポンス書き込みエラーの伝播**
```go
// Before（c.JSON のエラーを捨て、さらに return err で二重書き込み）
if err != nil {
    c.JSON(http.StatusNotFound, user)
    return err
} else {
    c.JSON(http.StatusOK, user)
    return nil
}
// After（c.JSON の結果をそのまま return）
if err != nil {
    return c.JSON(http.StatusNotFound, user)
}
return c.JSON(http.StatusOK, user)
```
`c.JSON` の error を Echo に伝播。あわせて「`c.JSON` を裸で呼んだ後 `return err`」していた**二重書き込み**も解消。エラー時は 404 + user ボディを返す挙動。

## スコープ外（別途）

- `c.Request().Header["Access-Token"][0]` はヘッダ不在で panic しうる（`.Get("Access-Token")` が安全）。errcheck の対象外のため本PRでは触れていない。

## Test plan

- [x] `cd api && go build ./...` 通過
- [x] `golangci-lint run --enable-only errcheck` が **0 issues**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * サーバー起動失敗時のエラーハンドリングを改善しました。
  * ユーザー関連APIのエラーレスポンスの一貫性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->