### PR TITLE
chore: CodeRabbit に golangci-lint の config_file を明示 (#373)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -3,5 +3,8 @@ reviews:
   profile: chill
   auto_review:
     enabled: true
+  tools:
+    golangci-lint:
+      config_file: "api/.golangci.yml"
 chat:
   auto_reply: true


### PR DESCRIPTION
## Summary

CodeRabbit の golangci-lint が `directory prefix . does not contain main module` で失敗する問題（#373）の **Step 1**。`.coderabbit.yaml` に `config_file: "api/.golangci.yml"` を明示し、CodeRabbit が api/ モジュールを正しく lint できるか試す。

```yaml
reviews:
  tools:
    golangci-lint:
      config_file: "api/.golangci.yml"
```

Refs #373

## 背景（根本原因）

CodeRabbit は golangci-lint を **root で `./...` 実行**するが、SeeFT の go.mod は **api/ のみ**（root に無し）。working directory を指定する手段が CodeRabbit に無いため失敗していた。`config_file` が cwd を api/ にする保証は docs に無いが、**1行・ゼロリスク**で効果を実地確認する。

## この PR 自体が検証ケース

この PR に対する CodeRabbit のレビューで、サマリ末尾「all tool run failures」を確認する。

- golangci-lint の `directory prefix .` エラーが**消えていれば成功**（→ #373 クローズ、CI不要）
- 消えなければ Step 2（GitHub Actions へ移して CodeRabbit では無効化）へ

> 注: CodeRabbit が現在レート上限のため、レビューが回らない場合は上限回復後に `@coderabbitai review` を実行して観測する。

## Test plan

- [ ] この PR に対する CodeRabbit レビューで golangci-lint のツール失敗が消えるか確認
- [ ] lint 指摘がインラインで出れば、api/ が正しく lint されている確証

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * linter設定の管理を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->