### PR TITLE
ci: golangci-lint の GitHub Actions を追加 (#373)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,24 @@
+name: lint
+
+on:
+  pull_request:
+    paths:
+      - "api/**"
+
+permissions:
+  contents: read
+
+jobs:
+  golangci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v7
+        with:
+          version: v2.12
+          working-directory: api
+          only-new-issues: true


### PR DESCRIPTION
## Summary

CodeRabbit は golangci-lint を **root 起点で `./...` 実行**し、Go モジュールが api/ サブディレクトリにある本リポでは原理的に動かせない（#373）。回数無制限・CodeRabbit のクレジットに非依存な **GitHub Actions** で golangci-lint を `working-directory: api` 実行に置き換える。

Refs #373

## ワークフロー

```yaml
- uses: golangci/golangci-lint-action@v7
  with:
    version: v2.12
    working-directory: api      # ← CodeRabbit に無い、api/ で実行する指定
    only-new-issues: true       # ← 既存負債(約74件)を無視し、PR新規分だけ検査
```

- **`working-directory: api`**: go.mod のある api/ で実行。CodeRabbit の `directory prefix . does not contain main module` を構造的に回避。
- **`only-new-issues: true`**: 既存の lint 負債（ineffassign 約70・gosec 2・unused 2）で全PRが赤くならないよう、PR の差分で新規に増えた指摘だけを落とす（`--new-from-patch`）。
- action は golangci-lint v2 対応の **v7**、`version: v2.12`（CodeRabbit と同じ系統）。

## 実地検証済み

PR #372 のブランチ上でこのワークフローを動かし、**成功を確認済み**：

```text
Running golangci-lint-2.12.2 run --new-from-patch=... --path-prefix=api
  in [/home/runner/work/SeeFT/SeeFT/api]   ← api/ で実行されている
"0 issues." / "golangci-lint found no issues" → 45秒で pass（緑）
```

## 補足

- このPRは `.github/workflows/` のみの変更で `api/**` を含まないため、path filter によりこのPR自体では lint は起動しない（仕様）。develop マージ後、api/ を変更する以後の全PRで自動起動する。
- CodeRabbit の golangci-lint は #374（config_file）で改善が見込めるため**無効化せず併存**（クレジットがある時のレビュー補助として残す）。CI が確実な lint の担保、CodeRabbit は best-effort、という二段構え。
- ログに Node 20 deprecation 警告が出るが非ブロッキング。将来 checkout@v5 / action@v8+ に上げれば解消。

## Test plan

- [x] PR #372 ブランチ上で golangci-lint が api/ で動作し pass することを確認済み
- [ ] develop マージ後、次に api/ を変更する PR で自動起動・pass することを確認