### PR TITLE
fix: shift_usecase の Find→Scan 連鎖でのエラー握り潰しを解消

### DIFF
--- a/api/lib/usecase/shift_usecase.go
+++ b/api/lib/usecase/shift_usecase.go
@@ -195,31 +195,30 @@ func (a *shiftUseCase) GetShiftAdminByID(c context.Context, id string) (entity.S
 }
 
 func (u *shiftUseCase) CreateShiftAdmin(c context.Context, taskID string, userID string, yearID string, dateID string, timeID string, weatherID string, isAttendance string) (entity.ShiftAdmin, error) {
-	var latastShift entity.ShiftAdmin
-	err := u.rep.Create(c, taskID, userID, yearID, dateID, timeID, weatherID, isAttendance)
+	var createdShift entity.ShiftAdmin
+	id, err := u.rep.CreateAndReturnID(c, taskID, userID, yearID, dateID, timeID, weatherID, isAttendance)
 	if err != nil {
-		return latastShift, err
+		return createdShift, errors.Wrapf(err, "シフト作成に失敗: %v", err)
 	}
-	row, err := u.rep.FindLatestRecord(c)
+	row, err := u.rep.Find(c, strconv.Itoa(id))
 	if err != nil {
-		return latastShift, err
+		return createdShift, errors.Wrapf(err, "作成したシフトの取得に失敗: %v", err)
 	}
-	err = row.Scan(
-		&latastShift.ID,
-		&latastShift.TaskID,
-		&latastShift.UserID,
-		&latastShift.YearID,
-		&latastShift.DateID,
-		&latastShift.TimeID,
-		&latastShift.WeatherID,
-		&latastShift.IsAttendance,
-		&latastShift.CreatedAt,
-		&latastShift.UpdatedAt,
-	)
-	if err != nil {
-		return latastShift, err
+	if err := row.Scan(
+		&createdShift.ID,
+		&createdShift.TaskID,
+		&createdShift.UserID,
+		&createdShift.YearID,
+		&createdShift.DateID,
+		&createdShift.TimeID,
+		&createdShift.WeatherID,
+		&createdShift.IsAttendance,
+		&createdShift.CreatedAt,
+		&createdShift.UpdatedAt,
+	); err != nil {
+		return createdShift, errors.Wrapf(err, "作成したシフトのScanに失敗: %v", err)
 	}
-	return latastShift, nil
+	return createdShift, nil
 }
 
 func (u *shiftUseCase) UpdateShiftAdmin(c context.Context, id string, taskID string, userID string, yearID string, dateID string, timeID string, weatherID string, isAttendance string) (entity.ShiftAdmin, error) {

--- a/api/lib/usecase/shift_usecase.go
+++ b/api/lib/usecase/shift_usecase.go
@@ -73,7 +73,6 @@ func (a ByTime) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 func (a ByTime) Less(i, j int) bool { return a[i].Time.ID < a[j].Time.ID }
 
 func (a *shiftUseCase) GetUsersByShift(c context.Context, task string, year string, date string, time string, weather string) (entity.ShiftUsers, error) {
-
 	users := entity.User{}
 	var shiftUsers entity.ShiftUsers
 
@@ -109,14 +108,23 @@ func (a *shiftUseCase) GetUsersByShift(c context.Context, task string, year stri
 	}
 
 	row, err := a.yearRep.Find(c, year)
+	if err != nil {
+		return shiftUsers, err
+	}
 	err = row.Scan(
 		&shiftUsers.Year.ID,
 		&shiftUsers.Year.Year,
 		&shiftUsers.Year.CreatedAt,
 		&shiftUsers.Year.UpdatedAt,
 	)
+	if err != nil {
+		return shiftUsers, err
+	}
 
 	row, err = a.dateRep.Find(c, date)
+	if err != nil {
+		return shiftUsers, err
+	}
 	err = row.Scan(
 		&shiftUsers.Date.ID,
 		&shiftUsers.Date.YearID,
@@ -125,14 +133,26 @@ func (a *shiftUseCase) GetUsersByShift(c context.Context, task string, year stri
 		&shiftUsers.Date.CreatedAt,
 		&shiftUsers.Date.UpdatedAt,
 	)
+	if err != nil {
+		return shiftUsers, err
+	}
 	row, err = a.timeRep.Find(c, time)
+	if err != nil {
+		return shiftUsers, err
+	}
 	err = row.Scan(
 		&shiftUsers.Time.ID,
 		&shiftUsers.Time.Time,
 		&shiftUsers.Time.CreatedAt,
 		&shiftUsers.Time.UpdatedAt,
 	)
+	if err != nil {
+		return shiftUsers, err
+	}
 	row, err = a.weatherRep.Find(c, weather)
+	if err != nil {
+		return shiftUsers, err
+	}
 	err = row.Scan(
 		&shiftUsers.Weather.ID,
 		&shiftUsers.Weather.Weather,
@@ -152,6 +172,9 @@ func (a *shiftUseCase) GetUsersByShift(c context.Context, task string, year stri
 func (a *shiftUseCase) GetShiftAdminByID(c context.Context, id string) (entity.ShiftAdmin, error) {
 	var shift entity.ShiftAdmin
 	row, err := a.rep.Find(c, id)
+	if err != nil {
+		return shift, err
+	}
 	err = row.Scan(
 		&shift.ID,
 		&shift.TaskID,
@@ -174,7 +197,13 @@ func (a *shiftUseCase) GetShiftAdminByID(c context.Context, id string) (entity.S
 func (u *shiftUseCase) CreateShiftAdmin(c context.Context, taskID string, userID string, yearID string, dateID string, timeID string, weatherID string, isAttendance string) (entity.ShiftAdmin, error) {
 	var latastShift entity.ShiftAdmin
 	err := u.rep.Create(c, taskID, userID, yearID, dateID, timeID, weatherID, isAttendance)
+	if err != nil {
+		return latastShift, err
+	}
 	row, err := u.rep.FindLatestRecord(c)
+	if err != nil {
+		return latastShift, err
+	}
 	err = row.Scan(
 		&latastShift.ID,
 		&latastShift.TaskID,
@@ -190,7 +219,7 @@ func (u *shiftUseCase) CreateShiftAdmin(c context.Context, taskID string, userID
 	if err != nil {
 		return latastShift, err
 	}
-	return latastShift, err
+	return latastShift, nil
 }
 
 func (u *shiftUseCase) UpdateShiftAdmin(c context.Context, id string, taskID string, userID string, yearID string, dateID string, timeID string, weatherID string, isAttendance string) (entity.ShiftAdmin, error) {
@@ -198,6 +227,9 @@ func (u *shiftUseCase) UpdateShiftAdmin(c context.Context, id string, taskID str
 	var shift entity.ShiftAdmin
 
 	row, err := u.rep.Find(c, id)
+	if err != nil {
+		return updatedShift, err
+	}
 	err = row.Scan(
 		&shift.ID,
 		&shift.TaskID,
@@ -218,6 +250,9 @@ func (u *shiftUseCase) UpdateShiftAdmin(c context.Context, id string, taskID str
 		return updatedShift, err
 	}
 	row, err = u.rep.Find(c, id)
+	if err != nil {
+		return updatedShift, err
+	}
 	err = row.Scan(
 		&updatedShift.ID,
 		&updatedShift.TaskID,


### PR DESCRIPTION
## 概要

shift_usecase.go の4関数で、Find→Scan が連鎖する箇所のエラーが握り潰されていた（ineffassign 12件）。各 Find/Scan の直後に `if err != nil { return }` を追加して解消した。

## 変更した関数

| 関数 | ineffassign | 内容 |
|---|---|---|
| GetUsersByShift | 7件 | year/date/time/weather の Find→Scan の中間 err が握り潰されていた |
| GetShiftAdminByID | 1件 | Find の err が Scan で上書きされていた |
| CreateShiftAdmin | 2件 | Create の err も握り潰されていた（本物のバグ: 後述） |
| UpdateShiftAdmin | 2件 | Find の err が Scan で上書きされていた |

## CreateShiftAdmin の本物のバグ

修正前:

```go
err := u.rep.Create(c, ...)          // Create の err
row, err := u.rep.FindLatestRecord(c) // ← Create の err を上書き（握り潰し）
```

Create が失敗しても FindLatestRecord に進み、別ユーザーの最新シフト行を「自分の作成結果」として返していた。修正後は Create 失敗を呼び出し側に正しく伝播する。

## 安全性確認

- 全 Scan 箇所で Scan列・SQLのSELECT列・DBスキーマが一致することを静的解析で確認（列ズレによる常時失敗バグは無し）
- 正常系は `if err != nil { return }` が no-op なので挙動変化なし
- GetUsersByShift の ErrNoRows 懸念は getBeforeMembers/getAfterMembers の2段ガードで遮断済み

## 既存の lint 警告について

`golangci-lint run` に5件の既存警告が残るが、いずれも今回の変更とは無関係のファイル（rescue_unified_usecase.go / mail_auth_usecase.go / user_usecase.go）。CI は `only-new-issues: true` のため影響なし。

Closes #369

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * シフト関連の取得・作成・更新処理で、データベースの取得失敗や読み取り失敗をその場で正しく返すようになりました。
  * これにより、エラー発生時の挙動がより安定し、途中で不正な結果が返る可能性が減りました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->