### PR TITLE
fix: mail_auth_usecase の SignIn で Scan のエラー握り潰しを解消

### DIFF
--- a/api/lib/usecase/mail_auth_usecase.go
+++ b/api/lib/usecase/mail_auth_usecase.go
@@ -35,7 +35,7 @@ func (u *mailAuthUseCase) SignIn(c context.Context, studentNumber string, passwo
 
 	// メールアドレスの存在確認
 	row := u.userRep.FindByStudentNumber(c, studentNumber)
-	err := row.Scan(
+	if err := row.Scan(
 		&user.ID,
 		&user.Name,
 		&user.Mail,
@@ -49,11 +49,14 @@ func (u *mailAuthUseCase) SignIn(c context.Context, studentNumber string, passwo
 		&user.CreatedAt,
 		&user.UpdatedAt,
 		&user.SlackUserID,
-	)
+	); err != nil {
+		return entity.LoginUser{}, errors.Wrapf(err, "ユーザーの取得に失敗: %v", err)
+	}
+
 	// パスワードがあっているか確認
 	password = strings.ReplaceAll(password, " ", "")
 	password = strings.ReplaceAll(password, "　", "")
-	err = bcrypt.CompareHashAndPassword([]byte(user.Password), []byte(password))
+	err := bcrypt.CompareHashAndPassword([]byte(user.Password), []byte(password))
 
 	loginUser := entity.LoginUser{ID: user.ID, RoleID: user.RoleID, Mail: user.Mail}
 


### PR DESCRIPTION
## 概要

\`SignIn\` 関数で \`row.Scan\` の err が \`bcrypt.CompareHashAndPassword\` の代入で上書きされ、Scan のエラーが握り潰されていた（ineffassign 1件）を修正した。

## 変更内容
```
go
// before
err := row.Scan(...)                          // Scan の err
err = bcrypt.CompareHashAndPassword(...)      // 上書き → Scan の err が消える

// after
if err := row.Scan(...); err != nil {
    return entity.LoginUser{}, errors.Wrapf(err, "ユーザーの取得に失敗: %v", err)
}
err := bcrypt.CompareHashAndPassword(...)     // Scan が成功した場合のみここに来る
```

Scan 失敗時（ユーザーが存在しない等）に即 return するようにした。修正前は \`user.Password\` が空文字のまま bcrypt に渡されていた。

Closes #379
Refs #314

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * サインイン時のユーザー取得失敗をより確実に検知し、失敗時は適切なエラーを返すようになりました。
  * パスワード照合時のエラーフローを整理し、認証失敗時の挙動が安定しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->