### PR TITLE
fix: RESCUE_GAS_URL に https スキーム検証を追加し gosec G704 を解消

### DIFF
--- a/api/lib/usecase/rescue_unified_usecase.go
+++ b/api/lib/usecase/rescue_unified_usecase.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"sort"
 	"strconv"
@@ -289,6 +290,10 @@ func (ru *rescueUnifiedUseCase) SendRescueToGAS(data map[string]interface{}) err
 	if gasURL == "" {
 		return errors.New("GAS URLが設定されていません (RESCUE_GAS_URL)")
 	}
+	parsedURL, err := url.Parse(gasURL)
+	if err != nil || parsedURL.Scheme != "https" {
+		return errors.New("RESCUE_GAS_URL が不正です（https のみ許可）")
+	}
 
 	// JSONに変換
 	jsonData, err := json.Marshal(data)
@@ -296,14 +301,14 @@ func (ru *rescueUnifiedUseCase) SendRescueToGAS(data map[string]interface{}) err
 		return errors.Wrap(err, "レスキューデータのJSON変換失敗")
 	}
 
-	req, err := http.NewRequest("POST", gasURL, bytes.NewBuffer(jsonData))
+	req, err := http.NewRequest("POST", gasURL, bytes.NewBuffer(jsonData)) //nolint:gosec // G704: gasURL はhttps スキームを検証済みの環境変数
 	if err != nil {
 		return errors.Wrap(err, "GASリクエスト作成失敗")
 	}
 	req.Header.Set("Content-Type", "application/json")
 
 	client := &http.Client{}
-	resp, err := client.Do(req)
+	resp, err := client.Do(req) //nolint:gosec // G704: gasURL はhttps スキームを検証済みの環境変数
 	if err != nil {
 		return errors.Wrap(err, "GASへの送信失敗")
 	}


### PR DESCRIPTION
## 概要

`rescue_unified_usecase.go` の `SendRescueToGAS` で、`gasURL` が `os.Getenv` 由来のため gosec G704（SSRF via taint analysis）が2件報告されていた。

## 変更内容

`gasURL == ""` チェックの直後に `url.Parse` で https スキームのみ許可する検証を追加した。

```go
parsedURL, err := url.Parse(gasURL)
if err != nil || parsedURL.Scheme != "https" {
    return errors.New("RESCUE_GAS_URL が不正です（https のみ許可）")
}
```

gosec の taint analysis は検証後も `os.Getenv` 由来の変数を汚染追跡し続けるため、警告を完全に消すには `//nolint:gosec` を理由コメントつきで付与した。

## 対応の意図

- url.Parse による https 検証: 設定ミスで http:// や不正な URL が入った場合にエラーで弾く（実際の安全性向上）
- //nolint:gosec: 「上で https スキームを検証済みの環境変数」という理由を明記して静的解析を抑制

## 残るリスク

`gasURL` は環境変数（運用者だけが設定可能）なので、ユーザー入力による SSRF は発生しない。https 検証により設定ミスの事故も防ぐ。

Closes #317
Refs #314