### PR TITLE
refactor: unnecessary_new 違反を解消 (#289)

### DIFF
--- a/mobile/lib/pages/users_page.dart
+++ b/mobile/lib/pages/users_page.dart
@@ -100,9 +100,9 @@ class _UsersPageState extends State<UsersPage> {
 
   Widget _manualItem(var users, index, context) {
     return Container(
-      decoration: new BoxDecoration(
+      decoration: BoxDecoration(
           border:
-              new Border(bottom: BorderSide(width: 1.0, color: Colors.grey))),
+              Border(bottom: BorderSide(width: 1.0, color: Colors.grey))),
       child: ListTile(
         title: Text(
           users[index]["name"].toString(),
@@ -139,9 +139,9 @@ class _UsersPageState extends State<UsersPage> {
     var roleID = await store.getRoleID();
     var value = await showDialog(
       context: context,
-      builder: (BuildContext context) => new AlertDialog(
-        title: new Text('ユーザ情報'),
-        content: new SizedBox(
+      builder: (BuildContext context) => AlertDialog(
+        title: Text('ユーザ情報'),
+        content: SizedBox(
           height: 200,
           width: 300,
           child: ListView(children: <Widget>[
@@ -177,8 +177,8 @@ class _UsersPageState extends State<UsersPage> {
           ]),
         ),
         actions: <Widget>[
-          new SimpleDialogOption(
-            child: new Text('OK'),
+          SimpleDialogOption(
+            child: Text('OK'),
             onPressed: () => Navigator.of(context).pop(),
           )
         ],

--- a/mobile/lib/widgets/first_jump_selector.dart
+++ b/mobile/lib/widgets/first_jump_selector.dart
@@ -6,7 +6,7 @@ class FirstJumpSelector extends StatefulWidget {
   const FirstJumpSelector({super.key});
 
   @override
-  State<FirstJumpSelector> createState() => new _FirstJumpSelectorState();
+  State<FirstJumpSelector> createState() => _FirstJumpSelectorState();
 }
 
 class _FirstJumpSelectorState extends State<FirstJumpSelector> {
@@ -63,7 +63,7 @@ class _FirstJumpSelectorState extends State<FirstJumpSelector> {
             homeWidget = '/signin';
           }
 
-          app = new MaterialApp(
+          app = MaterialApp(
             title: constant.appName,
             theme: materialTheme.light(), // ライトモードのテーマ
               darkTheme: materialTheme.dark(), // ダークモードのテーマ
@@ -75,7 +75,7 @@ class _FirstJumpSelectorState extends State<FirstJumpSelector> {
             },
           );
         } else if (snapshot.hasError) {
-          app = new MaterialApp(
+          app = MaterialApp(
             title: constant.appName,
             theme: materialTheme.light(), // ライトモードのテーマ
               darkTheme: materialTheme.dark(), // ダークモードのテーマ

--- a/mobile/lib/widgets/table.dart
+++ b/mobile/lib/widgets/table.dart
@@ -47,7 +47,7 @@ class ShiftTable {
                   TableCell(
                       child: Container(
                     alignment: Alignment.center,
-                    child: new Text(shifts[index]["time"]["time"]),
+                    child: Text(shifts[index]["time"]["time"]),
                   )),
                   TableCell(
                       /*
@@ -64,7 +64,7 @@ class ShiftTable {
                     //color: HexColor(shifts[index]["Color"].toString()),
                     padding: EdgeInsets.all(0),
                     //height: 25.0,
-                    child: new Material(
+                    child: Material(
                       type: MaterialType.button,
                       color: HexColor(shifts[index]["task"]["color"]),
                       child: InkWell(
@@ -83,7 +83,7 @@ class ShiftTable {
                         },
                         //child: Center(child: new Text(shifts[index]["Work"].toString())),
                         child: Center(
-                              child: new Text(
+                              child: Text(
                                   shifts[index]["task"]["task"].toString())),
                         ),
                       ),


### PR DESCRIPTION
## 概要

flutter_lints の `unnecessary_new` 違反を解消しました。`fvm dart fix --apply --code=unnecessary_new` による自動修正で、`new Foo()` 形式を Dart 2 以降の標準である `Foo()` 形式へ揃えています。ロジックの変更はありません（全件が `new` キーワードの削除のみ）。

Close #289

## 件数について

Issue 記載は 14件・4ファイル（`wait_page.dart` 1件込み）でしたが、実測では **13件・3ファイル**でした。`wait_page.dart` には現在 `new` の使用がなく、別対応で既に解消済みのようです。現状に合わせて 13件を修正しています。

修正内訳:

```text
lib/pages/users_page.dart             7件
lib/widgets/first_jump_selector.dart  3件
lib/widgets/table.dart                3件
```

## 確認

`fvm flutter analyze` の `unnecessary_new` 残数が 0 件になったことを確認済みです。

```bash
cd mobile && fvm flutter analyze
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * 画面内のウィジェット生成を整理し、古い記法を統一しました。
  * ユーザー一覧、初期表示 चयन択画面、シフト表の表示はこれまでと同じ見た目・動作を維持しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->