### PR TITLE
fix: use_build_context_synchronously 違反を解消 (#285)

### DIFF
--- a/mobile/lib/pages/rescue/rescue_request_tab/tab_pages/question.dart
+++ b/mobile/lib/pages/rescue/rescue_request_tab/tab_pages/question.dart
@@ -32,11 +32,11 @@ class RescueRequestTabQuestionPage extends StatelessWidget {
       await api.postQuestionRescue(userId, question);
 
       logger.i('Question report sent successfully.');
-      showCustomSnackBar(context, "レスキューを送信しました");
+      if (context.mounted) showCustomSnackBar(context, "レスキューを送信しました");
       return true;
     } catch (e) {
       logger.e('Failed to send question report: $e');
-      showCustomErrorSnackBar(context, "レスキューの送信に失敗しました");
+      if (context.mounted) showCustomErrorSnackBar(context, "レスキューの送信に失敗しました");
       return false;
     }
   }
@@ -119,6 +119,7 @@ class RescueRequestTabQuestionPage extends StatelessWidget {
                   context,
                   question,
                 );
+                if (!context.mounted) return;
                 logger.i("レスキューを送信しました");
                 if(isSuccess){
                   // 最初の画面まで戻る

--- a/mobile/lib/pages/rescue/rescue_request_tab/tab_pages/shorthanded.dart
+++ b/mobile/lib/pages/rescue/rescue_request_tab/tab_pages/shorthanded.dart
@@ -73,14 +73,14 @@ class RescueRequestTabShorthandedPage extends StatelessWidget {
       place == ""
     ) {
       logger.e('Invalid input data');
-      showCustomErrorSnackBar(context, "データが入力されていません");
+      if (context.mounted) showCustomErrorSnackBar(context, "データが入力されていません");
       return false;
     }
     if(
       selectedTask.id == 0
     ) {
       logger.e('taskID is Invalid');
-      showCustomErrorSnackBar(context, "タスクを選択してください");
+      if (context.mounted) showCustomErrorSnackBar(context, "タスクを選択してください");
       return false;
     }
     try {
@@ -94,11 +94,11 @@ class RescueRequestTabShorthandedPage extends StatelessWidget {
       await api.postShorthandedRescue(userId, selectedTask.id, missingNumber, place);
 
       logger.i('Shorthanded report sent successfully.');
-      showCustomSnackBar(context, "レスキューを送信しました");
+      if (context.mounted) showCustomSnackBar(context, "レスキューを送信しました");
       return true;
     } catch (e) {
       logger.e('Failed to send shorthanded report: $e');
-      showCustomErrorSnackBar(context, "レスキューの送信に失敗しました");
+      if (context.mounted) showCustomErrorSnackBar(context, "レスキューの送信に失敗しました");
       return false;
     }
   }
@@ -353,6 +353,7 @@ class RescueRequestTabShorthandedPage extends StatelessWidget {
                         missingNumber,
                         place,
                       );
+                      if (!context.mounted) return;
                       logger.i("レスキューを送信しました");
                       if(isSuccess){
                         // 最初の画面まで戻る

--- a/mobile/lib/pages/rescue/rescue_request_tab/tab_pages/trouble.dart
+++ b/mobile/lib/pages/rescue/rescue_request_tab/tab_pages/trouble.dart
@@ -72,7 +72,7 @@ class RescueRequestTabTroublePage extends StatelessWidget {
       place == ""
     ) {
       logger.e('Invalid input data');
-      showCustomErrorSnackBar(context, "データが入力されていません");
+      if (context.mounted) showCustomErrorSnackBar(context, "データが入力されていません");
       return false;
     }
     try {
@@ -91,11 +91,11 @@ class RescueRequestTabTroublePage extends StatelessWidget {
       );
 
       logger.i('Trouble report sent successfully.');
-      showCustomSnackBar(context, "レスキューを送信しました");
+      if (context.mounted) showCustomSnackBar(context, "レスキューを送信しました");
       return true;
     } catch (e) {
       logger.e('Failed to send trouble report: $e');
-      showCustomErrorSnackBar(context, "レスキューの送信に失敗しました");
+      if (context.mounted) showCustomErrorSnackBar(context, "レスキューの送信に失敗しました");
       return false;
     }
   }
@@ -349,6 +349,7 @@ class RescueRequestTabTroublePage extends StatelessWidget {
                         place,
                         detail
                       );
+                      if (!context.mounted) return;
                       logger.i("レスキューを送信しました");
                       if(isSuccess){
                         // 最初の画面まで戻る

--- a/mobile/lib/pages/rescue/rescue_response_tab/rescue_response_tab.dart
+++ b/mobile/lib/pages/rescue/rescue_response_tab/rescue_response_tab.dart
@@ -106,7 +106,8 @@ class _RescueResponseTabState extends State<RescueResponseTab> {
     
     // サーバーからデータを取得
     final List<dynamic>? fetchedData = await _getRescueResponses(userID);
-    
+    if (!mounted) {return;}
+
     // キャッシュデータとフェッチデータを比較
     if (fetchedData == null || deepEq(fetchedData, cachedData)) {
       // フェッチデータがnullまたはキャッシュデータと同じ場合は、キャッシュデータを使用

--- a/mobile/lib/pages/sign_in_page.dart
+++ b/mobile/lib/pages/sign_in_page.dart
@@ -34,6 +34,7 @@ class _SignInPageState extends State<SignInPage> {
             '/layout',
             (Route<dynamic> route) => false);
       } else {
+        if (!mounted) return;
         setState(() {
           ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
             content: Text('学籍番号もしくはパスワードが違います'),
@@ -42,6 +43,7 @@ class _SignInPageState extends State<SignInPage> {
         });
       }
     } catch (e) {
+      if (!mounted) return;
       setState(() {
         ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
           content: Text('学籍番号もしくはパスワードが違います'),

--- a/mobile/lib/pages/sign_in_page.dart
+++ b/mobile/lib/pages/sign_in_page.dart
@@ -25,6 +25,7 @@ class _SignInPageState extends State<SignInPage> {
         await store.setRoleID(resRoleId);
         // userIdをstoreにset出来てるか確認
         var userID = await store.getUserID();
+        if (!mounted) return;
         setState(() {
           infoText = "Your ID : $userID";
         });

--- a/mobile/lib/pages/users_page.dart
+++ b/mobile/lib/pages/users_page.dart
@@ -137,6 +137,7 @@ class _UsersPageState extends State<UsersPage> {
 
   Future userInfoModal(users, index) async {
     var roleID = await store.getRoleID();
+    if (!mounted) return;
     var value = await showDialog(
       context: context,
       builder: (BuildContext context) => AlertDialog(

--- a/mobile/lib/widgets/review_bottom_sheet.dart
+++ b/mobile/lib/widgets/review_bottom_sheet.dart
@@ -91,11 +91,11 @@ class _ReviewFormState extends State<ReviewForm> {
       await api.postReview(userID, taskName, staffingRating, manualRating, comment);
 
       logger.i('レビューの送信に成功しました');
-      showCustomSnackBar(context, "レビューを送信しました");
+      if (context.mounted) showCustomSnackBar(context, "レビューを送信しました");
       return true;
     } catch (e) {
       logger.e('レビューの送信に失敗しました: $e');
-      showCustomErrorSnackBar(context, "レビューの送信に失敗しました");
+      if (context.mounted) showCustomErrorSnackBar(context, "レビューの送信に失敗しました");
       return false;
     }
   }
@@ -114,6 +114,7 @@ class _ReviewFormState extends State<ReviewForm> {
       manualRating,
       _controller.text,
     );
+    if (!mounted) return;
     if(isSuccess){  // 送信成功時
       // Hiveにタスク名を保存
       reviewedTaskNameBox.put(widget.taskName, true);

--- a/mobile/lib/widgets/shift_dialog.dart
+++ b/mobile/lib/widgets/shift_dialog.dart
@@ -102,7 +102,7 @@ openShiftDialog(
   } else {
     resAfterUsers = 'none';
   }
-
+  if (!context.mounted) return;
   showDialog(
     context: context,
     builder: (context) {


### PR DESCRIPTION
## 概要

flutter_lints の `use_build_context_synchronously` 違反 16件を解消しました。`await`（非同期ギャップ）をまたいだ後に `BuildContext` を使っている箇所に、Widget のライフタイムを確認するガードを追加しています。

await の待機中にユーザーが画面を閉じる・移動すると Widget が破棄され、破棄後に `context`（`Navigator` / `ScaffoldMessenger` / `showDialog`）を使うと実行時例外になります。これを防ぐ修正です。

Close #285

## 修正方針

各箇所の文脈に応じて2つのガード形を使い分けています。

```text
囲い込み型  if (context.mounted) showCustomSnackBar(context, ...);
            └ await 後にも return など非UI処理が続くとき（戻り値 bool を返す関数）

早期 return  if (!mounted) return;
            └ await 後がすべて UI 操作で、まとめて中止してよいとき
```

State を持つ箇所は `mounted`（State プロパティ）、StatelessWidget や独立関数（`shift_dialog.dart`）は `context.mounted`（BuildContext プロパティ）を使用しています。

## 修正箇所

```text
lib/pages/rescue/rescue_request_tab/tab_pages/question.dart     3件
lib/pages/rescue/rescue_request_tab/tab_pages/shorthanded.dart  3件
lib/pages/rescue/rescue_request_tab/tab_pages/trouble.dart      3件
lib/widgets/review_bottom_sheet.dart                            3件
lib/pages/rescue/rescue_response_tab/rescue_response_tab.dart   1件
lib/pages/sign_in_page.dart                                     1件
lib/pages/users_page.dart                                       1件
lib/widgets/shift_dialog.dart                                   1件
```

## 確認

`fvm flutter analyze` が `No issues found!` になることを確認済みです。

```bash
cd mobile && fvm flutter analyze
```

## レビュー観点

本ルールは非同期処理と Widget ライフサイクルの理解を要し、直し方を誤ると逆に実バグを埋め込むため要レビューです。特にガードを置く位置（await の直後か、UI 呼び出しの直前か）と、`mounted` / `context.mounted` の選択が妥当かをご確認ください。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 画面遷移やダイアログ表示、SnackBar表示の前に有効な画面状態を確認するようになりました。
  * 送信後や読み込み後に、画面が閉じられている場合は更新処理やナビゲーションを行わないよう改善しました。
  * サインイン、ユーザー情報表示、レビュー送信などの操作で、破棄済み画面へのUI呼び出しを防止しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->