### PR TITLE
ci: GitHub Actions のアクションを SHA 固定 + go-lint へ整理（CIサプライチェーン保護）

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  # SHA 固定した GitHub Actions を自動更新する（go-lint.yml / flutter-lint.yml）。
+  # 固定したまま放置すると脆弱性修正を取りこぼすため、その逆リスクを Dependabot で解消する。
+  - package-ecosystem: "github-actions"
+    # "/" を指定すると .github/workflows 配下を走査する。
+    directory: "/"
+    schedule:
+      # weekly は「PRを毎週出す」ではなく「毎週更新を確認する」間隔。更新が無ければ無音。
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    # bump コミットの接頭辞。手動コミットの ci: と揃える。
+    commit-message:
+      prefix: "ci"
+    # 複数アクションの更新を1つの PR にまとめてレビュー回数を減らす。
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    # 公開直後の版は掴まず7日待つ。乗っ取り直後の悪意リリースを避ける猶予。
+    cooldown:
+      default-days: 7

--- a/.github/workflows/flutter-lint.yml
+++ b/.github/workflows/flutter-lint.yml
@@ -15,10 +15,10 @@ jobs:
       run:
         working-directory: mobile
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
-      - uses: subosito/flutter-action@v2
+      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
         with:
           flutter-version: 3.27.3
           channel: stable

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -1,4 +1,4 @@
-name: lint
+name: go-lint
 
 on:
   pull_request:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,12 +12,14 @@ jobs:
   golangci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: stable
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa # v7
         with:
           version: v2.12
           working-directory: api


### PR DESCRIPTION
Close #387

## やったこと

CI のサプライチェーン保護として、(1) 両ワークフローのアクションをコミット SHA に固定し、(2) `go-lint` の checkout で資格情報の永続化を無効化、(3) 固定 SHA が塩漬けになる逆リスクを Dependabot の自動更新で解消する。あわせてワークフロー名を `go-lint` に整理した。

コミットは関心事ごとに分割している。

```text
commit 1: SHA固定 + persist-credentials（#387 本体）
commit 2: ワークフローを go-lint にリネーム（命名整理）
commit 3: Dependabot 導入（固定SHAの自動更新）
```

## SHA 固定の内訳（タグ → コミットSHA）

`gh api repos/<repo>/commits/<tag>` でタグが指すコミットを解決して固定。各行にバージョンコメントを併記した。

```text
go-lint.yml
  actions/checkout              @v4 → 34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
  actions/setup-go              @v5 → 40f1582b2485089dde7abd97c1529aa768e1baff # v5
  golangci/golangci-lint-action @v7 → 9fae48acfc02a90574d7c304a1758ef9895495fa # v7

flutter-lint.yml
  actions/checkout              @v4 → 34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
  subosito/flutter-action       @v2 → 1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
```

加えて `go-lint.yml` の checkout に `persist-credentials: false` を追加（flutter-lint 側は #386 で対応済み）。

## Dependabot（固定の塩漬け対策）

SHA 固定は「タグ乗っ取りの自動実行」を防ぐ一方、固定 SHA が古いまま脆弱性修正を取りこぼす逆リスクがある。これを自動更新で解消する。Renovate は未インストール（GitHub Apps 一覧に無し）のため、GitHub ネイティブで追加インストール不要な Dependabot を採用した。

```text
.github/dependabot.yml
  package-ecosystem: github-actions（.github/workflows を走査）
  schedule: weekly（更新が無ければ PR は出ない。確認頻度の指定）
  groups: 全アクション更新を1 PR に集約
  cooldown: 公開から7日経った版のみ対象（出たて版/乗っ取り直後の悪意版を避ける）
  commit-message.prefix: ci
```

## 検証

```text
- 各 SHA は gh api でタグから解決した実在コミット
- go-lint.yml / flutter-lint.yml / dependabot.yml ともに YAML 構文 valid
- 挙動を保つため、メジャー更新（checkout v5/v7 等）はせず現行メジャーの SHA に固定。
  今後のメジャー更新は Dependabot のレビュー可能な PR 経由で行う
```

この PR は `.github/` のみの変更で `api/**` も `mobile/**` も触らないため、両ワークフローは本 PR 上では発火しない（self-trigger しない）。実 CI での発火確認は、マージ後に api / mobile を変更する次の PR で行われる。Dependabot の初回稼働もマージ後。
