### PR TITLE
fix: docker-compose の DB 初期化マウントを postgresql/db に修正

### DIFF
--- a/docker-compose.mac.yml
+++ b/docker-compose.mac.yml
@@ -5,8 +5,7 @@ services:
     container_name: nutfes-seeft-db
     image: postgres:18
     volumes:
-      - ./mysql/db:/docker-entrypoint-initdb.d/ # 初期データ
-      - ./my.cnf:/etc/mysql/conf.d/my.cnf
+      - ./postgresql/db:/docker-entrypoint-initdb.d/ # 初期データ
     environment:
       POSTGRES_DB: seeft_db
       POSTGRES_USER: seeft

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,7 @@ services:
     container_name: nutfes-seeft-db
     image: postgres:18
     volumes:
-      - ./mysql/db:/docker-entrypoint-initdb.d/ # 初期データ
-      - ./my.cnf:/etc/mysql/conf.d/my.cnf
+      - ./postgresql/db:/docker-entrypoint-initdb.d/ # 初期データ
     environment:
       POSTGRES_DB: seeft_db
       POSTGRES_USER: seeft


### PR DESCRIPTION
Close #394

## 背景

テストロードマップ（`docs/development/test-roadmap.md`）のフェーズ0。#277 で `mysql/` ディレクトリを `postgresql/` に改名した際の追随漏れで、docker-compose が存在しない `./mysql/db` を DB 初期化用にマウントしており、コンテナ初回起動時のテーブル作成・シード投入が機能していなかった。あわせて PostgreSQL コンテナには無意味な MySQL 設定ファイル `my.cnf` のマウントも残っていた。

## 変更内容

- `docker-compose.yml`: db サービスの初期化マウントを `./mysql/db` から `./postgresql/db` に修正し、`./my.cnf` のマウント行を削除
- `docker-compose.mac.yml`: 同上（記述は yml と同一だった）
- `docker-compose.prod.yml`: db サービス自体が存在しないため変更なし

`my.cnf` ファイル自体の削除は issue の記載どおり別途判断とし、本 PR では触っていない。

## 動作確認

DB ボリュームが存在しない状態から db サービスを起動し、initdb で `postgresql/db/*.sql` が適用されることを確認した。

構文確認:

```bash
docker compose config --quiet
```

エラーなしで通過（`docker-compose.mac.yml` は既存の `version` 属性の obsolete 警告のみで、本 PR のスコープ外）。

db 起動と healthcheck 通過:

```bash
docker compose up -d db
until docker compose exec db pg_isready -U seeft -d seeft_db; do sleep 2; done
```

```text
/var/run/postgresql:5432 - accepting connections
```

テーブル作成の確認:

```bash
docker compose exec db psql -U seeft -d seeft_db -c "\dt"
```

`action_logs`, `bureaus`, `dates`, `departments`, `grades`, `permissions`, `places`, `question_rescues`, `reviews`, `roles`, `session`, `shifts`, `shorthanded_rescues`, `tasks`, `times`, `trouble_rescues`, `users`, `weathers`, `years` の 19 テーブルが作成されていた。

seed.sql 適用の確認:

```bash
docker compose exec db psql -U seeft -d seeft_db -c "SELECT count(*) FROM bureaus;"
```

```text
 count
-------
     8
(1 row)
```

検証後は `docker compose down -v` でコンテナ・ネットワーク・ボリュームを削除済み。

## 関連

- ロードマップ: #391 / フェーズ0。フェーズ2（実 DB 統合テスト）の前提
- #277（ディレクトリ改名元）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * データベース初期化時の参照先を PostgreSQL 用の初期データ構成に切り替えました。
  * MySQL 向け設定のマウントを削除し、Docker 起動時のDB準備が PostgreSQL 前提になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->