### PR TITLE
ci: go test ワークフローを追加（テスト実行基盤）

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -1,0 +1,23 @@
+name: go-test
+
+on:
+  pull_request:
+    paths:
+      - "api/**"
+
+permissions:
+  contents: read
+
+jobs:
+  go-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version: stable
+      - name: go test
+        run: go test ./... -count=1
+        working-directory: api


### PR DESCRIPTION
Close #393

## 背景

テストロードマップ（`docs/development/test-roadmap.md`）のフェーズ0。テストを書き始める前に、書いたテストが PR ごとに自動実行される基盤を先に敷く。テストが 0 本の現状でも「0 件実行で成功」として green になるため、フェーズ1 以降の全 PR が自動検証される状態を先に作る。

## 変更内容

`.github/workflows/go-test.yml` を新設。既存の `go-lint.yml` と同型の構成:

- `on: pull_request` / `paths: "api/**"`
- `permissions: contents: read`
- `actions/checkout` と `actions/setup-go` は go-lint.yml と同一の SHA 固定（#387 の方針に合わせる）
- checkout に `persist-credentials: false`
- setup-go は `go-version: stable`（#385 完了後に `go-version-file: api/go.mod` へ切替予定）
- テスト実行ステップは `go test ./... -count=1`（`working-directory: api`）

## 動作確認

YAML パース確認:

```bash
python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/go-test.yml'))"
```

エラーなく完了（パース成功）。

ホストの go でテスト実行:

```bash
cd api && go test ./... -count=1
```

全 13 パッケージが `[no test files]` で exit 0（テスト 0 本で green になることを確認）:

```text
?   	github.com/NUTFes/SeeFT/api	[no test files]
?   	github.com/NUTFes/SeeFT/api/cmd/send-notifications	[no test files]
...（計 13 パッケージすべて [no test files]）
exit=0
```

go-lint.yml との SHA 一致確認:

```bash
grep -n "uses:" .github/workflows/go-test.yml .github/workflows/go-lint.yml
```

`actions/checkout@34e11487...` / `actions/setup-go@40f1582b...` が両ファイルで一致。

## 補足

paths フィルタが `api/**` のため、この PR 自体では go-test は走らない。マージ後、`api/**` を変更する PR（例: #396 の PR）で初回実行される。

## 関連

- ロードマップ: #391 / フェーズ0
- #385（setup-go のバージョン指定方法に影響。完了後に `go-version-file` へ切替）
- #387（actions の SHA 固定方針）
