### PR TITLE
unused: shift_usecase の未使用グローバル変数を削除

### DIFF
--- a/api/lib/usecase/shift_usecase.go
+++ b/api/lib/usecase/shift_usecase.go
@@ -63,8 +63,6 @@ func NewShiftUseCase(
 	return &shiftUseCase{rep, shiftCardRep, taskRep, userRep, yearRep, dateRep, timeRep, weatherRep, placeRep, gradeRep, bureauRep, actionLogRepo}
 }
 
-var TaskID, UserID, YearID, DateID, TimeID, WeatherID, PlaceID string
-
 // 時間でソート
 type ByTime []entity.Shift
 


### PR DESCRIPTION
Close #396

## 背景

テストロードマップ（`docs/development/test-roadmap.md`）のフェーズ0。テスト導入前の下準備として、実使用箇所のない exported なミュータブルグローバル変数を削除する。テスト間で状態を共有しうる形のため、テスト導入前に消しておく。

## 変更内容

`api/lib/usecase/shift_usecase.go` のパッケージレベル宣言 1 行を削除した。

```go
var TaskID, UserID, YearID, DateID, TimeID, WeatherID, PlaceID string
```

entity の struct フィールド（`shift.TaskID` 等）や関数ローカル変数は同名でも別物のため触っていない。

## 動作確認

`api/` で `go build ./...` を実行し、exit 0 を確認した。

```console
$ go build ./...
exit=0
```

`api/` で `go vet ./...` を実行し、指摘なし・exit 0 を確認した。

```console
$ go vet ./...
exit=0
```

リポジトリルートで `make build`（docker compose build）を実行し、api / admin の両イメージのビルド成功と exit 0 を確認した。確認後は `docker compose down -v` で後始末済み。

```console
$ make build
 Image wf_7ad0e901-568-2-admin Built
 Image wf_7ad0e901-568-2-api Built
exit=0
```

パッケージレベル変数としての参照が残っていないことは、`usecase.TaskID` 等の grep がヒットしないことに加え、削除後のコンパイル成功（`go build ./...` exit 0）を最終根拠として確認した。
