### PR TITLE
feat: make test ターゲットを追加し AGENTS.md に記載

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ make build        # コンテナビルド
 make exec         # api コンテナにシェルログイン
 make seed         # DB シード投入
 make tidy         # go mod tidy（コンテナ内）
+make test         # go test ./...（コンテナ内）
 make mobile-up    # fvm flutter run -d web-server --web-port 45029 --dart-define-from-file=env/.env
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,10 @@ exec:
 tidy:
 	docker compose run --rm api go mod tidy
 
+.PHONY: test
+test:
+	docker compose run --rm api go test ./...
+
 .PHONY: go-init
 go-init:
 	docker compose run --rm api go mod init github.com/NUTFes/SeeFT/api


### PR DESCRIPTION
Close #395

## 背景

テストロードマップ（`docs/development/test-roadmap.md`）のフェーズ0。テストの実行手段が `Makefile` に用意されておらず、回し方もドキュメント化されていなかったため、`make up` などと同じ並びで `make test` を用意し、AGENTS.md の Commands 節に記載する。

## 変更内容

- `Makefile` に `test` ターゲットを追加。既存の `tidy` と同じくコンテナ内実行

```makefile
.PHONY: test
test:
	docker compose run --rm api go test ./...
```

- `AGENTS.md` の Commands 節に `make test` を追記

```bash
make tidy         # go mod tidy（コンテナ内）
make test         # go test ./...（コンテナ内）
```

## 動作確認

`make test` を実行（api イメージの初回ビルド・依存ダウンロードを含む）。全パッケージが `[no test files]` で exit code 0 になることを確認した。

```text
?   	github.com/NUTFes/SeeFT/api	[no test files]
?   	github.com/NUTFes/SeeFT/api/cmd/send-notifications	[no test files]
?   	github.com/NUTFes/SeeFT/api/docs	[no test files]
?   	github.com/NUTFes/SeeFT/api/lib/di	[no test files]
?   	github.com/NUTFes/SeeFT/api/lib/entity	[no test files]
?   	github.com/NUTFes/SeeFT/api/lib/externals/db	[no test files]
?   	github.com/NUTFes/SeeFT/api/lib/externals/server	[no test files]
?   	github.com/NUTFes/SeeFT/api/lib/externals/slack	[no test files]
?   	github.com/NUTFes/SeeFT/api/lib/internals/controller	[no test files]
?   	github.com/NUTFes/SeeFT/api/lib/internals/repository	[no test files]
?   	github.com/NUTFes/SeeFT/api/lib/internals/repository/abstract	[no test files]
?   	github.com/NUTFes/SeeFT/api/lib/router	[no test files]
?   	github.com/NUTFes/SeeFT/api/lib/usecase	[no test files]
```

確認後は `docker compose down -v` でコンテナ・ネットワーク・ボリュームを削除済み。

補足: 検証環境は #394 の修正前だったため、`docker compose` のマウント先 `./mysql/db` を空ディレクトリとして一時作成して実行した（コミット対象には含めていない）。

## 関連

- ロードマップ: #391 / フェーズ0
