### PR TITLE
fix: MaterialAppの構成をアプリ起動中に作り替えないよう修正し、起動直後のクラッシュを解消

### DIFF
--- a/mobile/lib/widgets/first_jump_selector.dart
+++ b/mobile/lib/widgets/first_jump_selector.dart
@@ -37,13 +37,16 @@ class _StartupScreen extends StatefulWidget {
 }
 
 class _StartupScreenState extends State<_StartupScreen> {
+  // initState で一度だけ生成し、再ビルドのたびに読み込みをやり直さないようにする
+  late final Future<bool> _prefReadFuture;
+
   @override
   void initState() {
     super.initState();
-    Timer(Duration(seconds: 3), () => logger.w('progress duration:'));
+    _prefReadFuture = _getPrefRead();
   }
 
-  Future<bool> getPrefRead() async {
+  Future<bool> _getPrefRead() async {
     try {
       final isUserID = await store.isUserID();
       final userID = await store.getUserID();
@@ -61,7 +64,7 @@ class _StartupScreenState extends State<_StartupScreen> {
     logger.i('navigated Splash.');
 
     return FutureBuilder<bool>(
-      future: getPrefRead(),
+      future: _prefReadFuture,
       builder: (BuildContext context, AsyncSnapshot<bool> snapshot) {
         logger.i('===============================');
         logger.i(snapshot.connectionState);

--- a/mobile/lib/widgets/first_jump_selector.dart
+++ b/mobile/lib/widgets/first_jump_selector.dart
@@ -2,14 +2,41 @@ import 'package:seeft_mobile/configs/importer.dart';
 import 'package:seeft_mobile/pages/sign_in_page.dart';
 import 'package:seeft_mobile/widgets/layout.dart';
 
-class FirstJumpSelector extends StatefulWidget {
+class FirstJumpSelector extends StatelessWidget {
   const FirstJumpSelector({super.key});
 
   @override
-  State<FirstJumpSelector> createState() => _FirstJumpSelectorState();
+  Widget build(BuildContext context) {
+    final materialTheme = MaterialTheme(Typography().black); // Typography() は変更が必要な可能性があります
+
+    // MaterialApp はここで1回だけ作る。ローディング中／未ログイン／ログイン済みの
+    // 画面切り替えは home の中身（_StartupScreen）だけで行い、
+    // MaterialApp 自体の設定（home / routes の形）は変えない。
+    return MaterialApp(
+      title: constant.appName,
+      theme: materialTheme.light(),
+      darkTheme: materialTheme.dark(),
+      themeMode: ThemeMode.light,
+      home: const _StartupScreen(),
+      routes: {
+        '/signin': (context) => SignInPage(),
+        '/layout': (context) => Layout(),
+      },
+    );
+  }
 }
 
-class _FirstJumpSelectorState extends State<FirstJumpSelector> {
+// アプリ起動直後に表示する画面。
+// ログイン済みかどうかを確認している間はローディング表示、
+// 確認が終わったらログイン画面 or マイシフト画面を表示する。
+class _StartupScreen extends StatefulWidget {
+  const _StartupScreen();
+
+  @override
+  State<_StartupScreen> createState() => _StartupScreenState();
+}
+
+class _StartupScreenState extends State<_StartupScreen> {
   @override
   void initState() {
     super.initState();
@@ -32,63 +59,40 @@ class _FirstJumpSelectorState extends State<FirstJumpSelector> {
   @override
   Widget build(BuildContext context) {
     logger.i('navigated Splash.');
-    final materialTheme = MaterialTheme(Typography().black); // Typography() は変更が必要な可能性があります
 
-    return FutureBuilder(
+    return FutureBuilder<bool>(
       future: getPrefRead(),
       builder: (BuildContext context, AsyncSnapshot<bool> snapshot) {
         logger.i('===============================');
         logger.i(snapshot.connectionState);
-        // 読み込み中（waiting）のデフォルト表示。hasData / hasError 時に上書きされる
-        Widget app = MaterialApp(
-          title: constant.appName,
-          theme: materialTheme.light(),
-          darkTheme: materialTheme.dark(),
-          themeMode: ThemeMode.light,
-          home: Scaffold(
+
+        if (snapshot.hasError) {
+          return Scaffold(
+            appBar: AppBar(
+              title: const Text('Error Message'),
+            ),
+            body: Column(children: [Text(snapshot.error.toString())]),
+          );
+        }
+
+        if (!snapshot.hasData) {
+          // 読み込み中（waiting）のデフォルト表示
+          return Scaffold(
             body: Center(
               child: CircularProgressIndicator(color: AppColors.main),
             ),
-          ),
-        );
-        if (snapshot.hasData) {
-          var isUserID = snapshot.data;
-          logger.i(snapshot.connectionState);
-          String homeWidget;
-          if (isUserID!) {
-            logger.i('select Layout.');
-            homeWidget = '/layout';
-          } else {
-            logger.i('select MainPage.');
-            homeWidget = '/signin';
-          }
-
-          app = MaterialApp(
-            title: constant.appName,
-            theme: materialTheme.light(), // ライトモードのテーマ
-              darkTheme: materialTheme.dark(), // ダークモードのテーマ
-              themeMode: ThemeMode.light, // ライトモードを適用
-            initialRoute: homeWidget,
-            routes: {
-              '/signin': (context) => SignInPage(),
-              '/layout': (context) => Layout(),
-            },
-          );
-        } else if (snapshot.hasError) {
-          app = MaterialApp(
-            title: constant.appName,
-            theme: materialTheme.light(), // ライトモードのテーマ
-              darkTheme: materialTheme.dark(), // ダークモードのテーマ
-              themeMode: ThemeMode.light, // ライトモードを適用
-            home: Scaffold(
-              appBar: AppBar(
-                title: const Text('Error Message'),
-              ),
-              body: Column(children: [Text(snapshot.error.toString())]),
-            ),
           );
         }
-        return app;
+
+        final isUserID = snapshot.data!;
+        logger.i(snapshot.connectionState);
+        if (isUserID) {
+          logger.i('select Layout.');
+          return Layout();
+        } else {
+          logger.i('select MainPage.');
+          return SignInPage();
+        }
       },
     );
   }


### PR DESCRIPTION
# 対応Issue
resolve #411

# 概要
アプリ起動直後、ログイン確認が終わった瞬間に画面が真っ赤になり `Unexpected null value.` でクラッシュする不具合を修正しました。

# 原因（かんたんな説明）

`mobile/lib/widgets/first_jump_selector.dart` が、読み込み中と読み込み後で「アプリ全体の土台」である `MaterialApp` の設定を作り替えていたことが原因でした。

> `MaterialApp` とは、アプリ全体のテーマや画面遷移（ルーティング）を管理する、Flutterアプリの一番外側の土台となるウィジェットです。

- 読み込み中: `MaterialApp(home: ローディング画面)`
- 読み込み後: `MaterialApp(initialRoute: '/layout', routes: {...})`（`home` は渡さない＝null）

Flutterは同じ場所に同じ種類のウィジェットが来ると、作り直さずに中身だけ更新します。そのため、最初に `home` 用に作られた「画面遷移の仕組み（Navigator）」の一部がそのまま生き残ってしまい、後から `home` が null になった状態でその仕組みが再利用されたときにクラッシュしていました。

実際に `-d chrome` でDartのデバッグ接続をして確認したところ、Flutter本体のコード（`packages/flutter/src/widgets/app.dart` 1476行目）にある `widget.home!` の部分で、想定外の null を踏んでいることを確認しました。

# 変更内容

`MaterialApp` を**最初から最後まで同じ形で1回だけ**作るようにしました。「読み込み中／未ログイン／ログイン済み」の画面の切り替えは、`MaterialApp` の中身（`home` の中の `_StartupScreen` という小さなウィジェット）だけで行うようにしています。既存のログ出力やユーザーID確認のロジックは変更していません。

```dart
// Before: 読み込み状況によって MaterialApp 自体の形（home / routes）が変わっていた
Widget app = MaterialApp(home: ローディング画面);
if (snapshot.hasData) {
  app = MaterialApp(initialRoute: homeWidget, routes: {...}); // home を渡さない別の形
}
return app;

// After: MaterialApp は1つの形のまま。中の画面だけを切り替える
return MaterialApp(
  home: const _StartupScreen(), // ローディング/ログイン画面/マイシフト画面はこの中で出し分ける
  routes: {'/signin': ..., '/layout': ...},
);
```

`_StartupScreen` の中身は、以前 `FirstJumpSelector` にあった `FutureBuilder` のロジックをそのまま移しただけです（`getPrefRead()` やログ出力は変更なし）。

# 画面スクリーンショット等
ローカルで実際に動かして目視確認しました（スクリーンショットはローカル確認のみで、このPR本文には添付していません）。
- 未ログイン状態 → ログイン画面（学籍番号・パスワード入力欄）が表示され、エラーは出ない
- ログイン済み状態 → マイシフト画面（タブ・下部ナビゲーション）が表示され、`Unexpected null value` は出ない

# テスト項目
- [x] `fvm flutter analyze --fatal-infos` でエラー・警告が0件であること
- [x] 未ログイン状態でアプリを起動し、エラーが出ずにログイン画面が表示されること
- [x] ログイン済み状態でアプリを起動し、エラーが出ずにマイシフト画面が表示されること

# 確認
実際に確認したコマンドと結果です。

```bash
$ cd mobile && fvm flutter analyze --fatal-infos
Analyzing mobile...
No issues found! (ran in 1.6s)
```

ブラウザ（`fvm flutter run -d web-server` → Chrome）で実際に起動し、ブラウザのコンソールを確認しました。

- 未ログイン状態: ログを最後まで確認し、`select MainPage.` （ログイン画面へ）まで到達。`Unexpected null value` や `EXCEPTION CAUGHT` は0件。
- ログイン済み状態（ブラウザの `localStorage` に `shared_preferences` 用のuserIDキーを仕込んで再現）: `select Layout.` （マイシフト画面へ）まで到達し、マイシフト画面が正しく表示された。`Unexpected null value` は0件（バックエンドAPIを起動していないため「データの取得に失敗しました」というAPIエラー表示は出るが、これは今回の不具合とは無関係で想定通り）。

# 備考
動作確認の途中で、今回の修正とは別の潜在バグ（マイシフト画面初回表示時の `LateInitializationError`。画面には赤いクラッシュ画面は出ず自動回復するため実害はないが、コンソールにはエラーが出る）を発見しました。今回のPRとは原因も対象ファイルも別のため、スコープ外として別issue #412 に切り出しています。

# CodeRabbitレビュー対応
CodeRabbitから4件の指摘があり、以下のとおり対応しました。

- 対応済み（追加コミットで反映）
  - `initState` 内のデバッグ用 `Timer`（3秒後にログを出すだけの処理）を削除
  - `getPrefRead` を `_getPrefRead` にリネーム（`_StartupScreenState` 内だけで使うprivateメソッドのため、AGENTS.mdの命名規則に合わせた）
  - `FutureBuilder` の `future` を `build()` 内で毎回生成せず、`initState` で1度だけ生成した `Future` を参照するように変更（再ビルドのたびに読み込み処理が再実行されるのを防止）
- 対応見送り（別issue化）
  - `_getPrefRead()` が例外をすべて `catch` して `false` を返すため `snapshot.hasError` の分岐が実質使われない、という指摘。仕様判断（読み込み失敗時に黙ってログイン画面を出すか、エラー画面を出すか）が必要なため、このPRのスコープ外として別issue #414 に切り出しています。

修正後、`fvm flutter analyze --fatal-infos` のクリーンな状態と、未ログイン／ログイン済み両方の動作を再確認済みです。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 起動時の画面判定を見直し、サインイン画面またはメイン画面が適切に表示されるようになりました。
  * 判定中はローディング表示を、エラー発生時はエラー画面を表示するようになりました。
  * アプリ内の画面遷移がより安定しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
