### PR TITLE
feat: マニュアル一覧にタスク名検索機能を追加 (#319)

### DIFF
--- a/mobile/lib/pages/manual_list_page.dart
+++ b/mobile/lib/pages/manual_list_page.dart
@@ -24,6 +24,7 @@ class _ManualListPageState extends State<ManualListPage> {
   final FocusNode _searchFocusNode = FocusNode();
   Timer? _debounce;
   bool _isLoading = true;
+  bool _hasError = false;
 
   @override
   void initState() {
@@ -79,17 +80,30 @@ class _ManualListPageState extends State<ManualListPage> {
       if (mounted) {
         setState(() {
           _allManuals = res as List<dynamic>;
+          _hasError = false;
           _isLoading = false;
         });
       }
     } catch (err) {
       logger.e('don`t response. error message: $err');
       if (mounted) {
+        // ロード失敗は「0件ヒット」とは別物として扱う。
+        // これがないとクエリ未入力時に空リスト＝真っ白な画面になる。
         setState(() {
+          _hasError = true;
           _isLoading = false;
         });
       }
     }
+  }
+
+  // エラー表示からの再読み込み。
+  void _retry() {
+    setState(() {
+      _isLoading = true;
+      _hasError = false;
+    });
+    _loadData();
   }
 
   List<dynamic> get _filteredManuals {
@@ -105,6 +119,12 @@ class _ManualListPageState extends State<ManualListPage> {
   Widget build(BuildContext context) {
     if (_isLoading) {
       return WaitPage();
+    }
+    if (_hasError) {
+      return Scaffold(
+        backgroundColor: AppColors.base,
+        body: _buildErrorView(),
+      );
     }
     final manuals = _filteredManuals;
     return Scaffold(
@@ -154,6 +174,37 @@ class _ManualListPageState extends State<ManualListPage> {
                         );
                       },
                     ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  // ロード失敗時の表示（再読み込み可能）。
+  Widget _buildErrorView() {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32.0),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Text(
+              'マニュアルの読み込みに失敗しました',
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                color: AppColors.textBlack,
+                fontSize: AppFontSizes.md,
+              ),
+            ),
+            const SizedBox(height: 16.0),
+            ElevatedButton(
+              style: ElevatedButton.styleFrom(
+                backgroundColor: AppColors.main,
+                foregroundColor: AppColors.textWhite,
+              ),
+              onPressed: _retry,
+              child: const Text('再読み込み'),
             ),
           ],
         ),

--- a/mobile/lib/pages/manual_list_page.dart
+++ b/mobile/lib/pages/manual_list_page.dart
@@ -118,7 +118,7 @@ class _ManualListPageState extends State<ManualListPage> {
   @override
   Widget build(BuildContext context) {
     if (_isLoading) {
-      return WaitPage();
+      return const WaitPage(message: 'マニュアルを読み込んでいます');
     }
     if (_hasError) {
       return Scaffold(

--- a/mobile/lib/pages/manual_list_page.dart
+++ b/mobile/lib/pages/manual_list_page.dart
@@ -18,45 +18,145 @@ class _ManualListPageState extends State<ManualListPage> {
 
 //  FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin;
 //  NotificationDetails platformChannelSpecifics;
-  int manualLength = 0;
+  List<dynamic> _allManuals = [];
+  String _searchQuery = '';
+  final TextEditingController _searchController = TextEditingController();
+  final FocusNode _searchFocusNode = FocusNode();
+  Timer? _debounce;
+  bool _isLoading = true;
 
   @override
   void initState() {
     super.initState();
+    // onChangedではなくcontrollerのリスナーを使う。
+    // IMEの変換確定は「テキストは同じでcomposing範囲だけがクリアされる」
+    // 変化として来ることがあり、onChangedでは取りこぼす場合があるため。
+    _searchController.addListener(_onSearchChanged);
+    _loadData();
+  }
+
+  @override
+  void dispose() {
+    _debounce?.cancel();
+    _searchController.removeListener(_onSearchChanged);
+    _searchController.dispose();
+    _searchFocusNode.dispose();
+    super.dispose();
+  }
+
+  // 検索入力のハンドラ（controllerリスナー）。
+  // 入力のたびに200msのデバウンスタイマーを張り直し、タイマー発火時点で
+  // まだIME変換中（composingが有効）ならフィルタ反映を見送る（仕様5.2）。
+  // 変換確定時はcomposingがクリアされて再度このリスナーが呼ばれるため、
+  // その後のタイマーで確実に反映される。
+  void _onSearchChanged() {
+    // クリアボタンの表示/非表示を即時反映する
+    setState(() {});
+    _debounce?.cancel();
+    _debounce = Timer(const Duration(milliseconds: 200), () {
+      if (!mounted) return;
+      // IME変換中はまだ確定していないので反映しない
+      if (_searchController.value.composing.isValid) return;
+      setState(() {
+        _searchQuery = _searchController.text;
+      });
+    });
+  }
+
+  void _clearSearch() {
+    _debounce?.cancel();
+    _searchController.clear();
+    setState(() {
+      _searchQuery = '';
+    });
+    // 連続検索しやすいようにフォーカスは検索ボックスに残す（仕様5.5）
+    _searchFocusNode.requestFocus();
+  }
+
+  Future<void> _loadData() async {
+    try {
+      final res = await api.getAllManual();
+      if (mounted) {
+        setState(() {
+          _allManuals = res as List<dynamic>;
+          _isLoading = false;
+        });
+      }
+    } catch (err) {
+      logger.e('don`t response. error message: $err');
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+      }
+    }
+  }
+
+  List<dynamic> get _filteredManuals {
+    // クエリ・タスク名の双方をトリム＋小文字化して部分一致（仕様5.3/6.3）
+    final query = _searchQuery.trim().toLowerCase();
+    if (query.isEmpty) return _allManuals;
+    return _allManuals
+        .where((m) => m["task"].toString().trim().toLowerCase().contains(query))
+        .toList();
   }
 
   @override
   Widget build(BuildContext context) {
+    if (_isLoading) {
+      return WaitPage();
+    }
+    final manuals = _filteredManuals;
     return Scaffold(
       backgroundColor: AppColors.base,
-      body: FutureBuilder(
-        future: getData(),
-        builder: (ctx, snapshot) {
-          if (snapshot.connectionState == ConnectionState.waiting) {
-            logger.i("Loading manual list...");
-          }
-          if (!snapshot.hasData) {
-            // 待機画面を表示
-            return WaitPage();
-          }
-          return Container(
-            padding: const EdgeInsets.all(32.0),
-            child: Column(
-              children: <Widget>[
-                Flexible(
-                  child: ListView.builder(
-                    itemCount: manualLength,
-                    itemBuilder: (BuildContext context, int index) {
-                      return SizedBox(
-                        height: 40,
-                        child: _manualItem(snapshot.data, index, context));
-                    },
+      body: Container(
+        padding: const EdgeInsets.all(32.0),
+        child: Column(
+          children: <Widget>[
+            Semantics(
+              label: 'マニュアル検索',
+              textField: true,
+              child: TextField(
+                controller: _searchController,
+                focusNode: _searchFocusNode,
+                decoration: InputDecoration(
+                  hintText: '検索',
+                  prefixIcon: const Icon(Icons.search),
+                  suffixIcon: _searchController.text.isNotEmpty
+                      ? IconButton(
+                          icon: const Icon(Icons.clear),
+                          onPressed: _clearSearch,
+                        )
+                      : null,
+                  enabledBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(AppBorderRadius.normal),
+                    borderSide: const BorderSide(color: AppColors.grayLight),
+                  ),
+                  focusedBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(AppBorderRadius.normal),
+                    borderSide: const BorderSide(color: AppColors.main),
                   ),
                 ),
-              ],
+              ),
             ),
-          );
-        },
+            const SizedBox(height: 16.0),
+            Flexible(
+              child: manuals.isEmpty && _searchQuery.trim().isNotEmpty
+                  ? const Center(
+                      child: Text('該当するマニュアルが見つかりませんでした'),
+                    )
+                  : ListView.builder(
+                      itemCount: manuals.length,
+                      itemBuilder: (BuildContext context, int index) {
+                        return SizedBox(
+                          height: 40,
+                          child: _manualItem(manuals, index, context),
+                        );
+                      },
+                    ),
+            ),
+          ],
+        ),
       ),
     );
   }
@@ -73,27 +173,16 @@ class _ManualListPageState extends State<ManualListPage> {
         title: Text(
           manuals[index]["task"].toString(),
           style: TextStyle(
-            color: AppColors.textBlack, 
-            fontSize: AppFontSizes.md
+            color: AppColors.textBlack,
+            fontSize: AppFontSizes.md,
           ),
         ),
         onTap: () async {
           if (await canLaunchUrl(Uri.parse(manuals[index]["url"].toString()))) {
             await launchUrl(Uri.parse((manuals[index]["url"].toString())));
           }
-          
         },
       ),
     );
-  }
-
-  Future getData() async {
-    try {
-      var res = await api.getAllManual();
-      manualLength = res.length;
-      return res;
-    } catch (err) {
-      logger.e('don`t response. error message: $err');
-    }
   }
 }

--- a/mobile/lib/pages/wait_page.dart
+++ b/mobile/lib/pages/wait_page.dart
@@ -3,7 +3,10 @@ import 'package:seeft_mobile/configs/importer.dart';
 import 'package:flutter/material.dart';
 
 class WaitPage extends StatefulWidget {
-  const WaitPage({super.key});
+  const WaitPage({super.key, this.message = 'シフトが完成するまでお待ちください'});
+
+  /// 待機中に表示する文言。呼び出し元の用途に合わせて差し替える。
+  final String message;
 
   @override
   State<WaitPage> createState() => _WaitPageState();
@@ -23,7 +26,13 @@ class _WaitPageState extends State<WaitPage> {
       body: Center(
         child: Column(
           mainAxisSize: MainAxisSize.min,
-          children:[ Text("シフトが完成するまでお待ちください",style: TextStyle(fontSize: 20),),],
+          children: [
+            Text(
+              widget.message,
+              textAlign: TextAlign.center,
+              style: const TextStyle(fontSize: 20),
+            ),
+          ],
         ),
       ),
     );


### PR DESCRIPTION
## 概要
マニュアル一覧ページに、タスク名による部分一致検索を追加しました。
タスク数の増加でスクロール目視での検索が困難になっていた課題を解消します。

Closes #319
仕様書: `docs/manual_search_spec.html`

## 変更内容
`mobile/lib/pages/manual_list_page.dart` にマニュアル検索を実装。

- **検索ボックス**: プレースホルダ「検索」/ 🔍アイコン / 入力がある時のみ✕クリアボタン表示
- **枠線カラー**: 通常 `#D9D9D9` / フォーカス時 `#009688`（既存の `AppColors` トークンを使用）
- **クライアント側フィルタ**: `GET /tasks` を全件取得し in-memory で絞り込み（API変更なし）
- **正規化**: クエリ・タスク名の双方を `trim()` + `toLowerCase()` して部分一致（大文字小文字を区別しない）
- **インクリメンタル検索**: 入力停止から 200ms デバウンス
- **IME制御**: `TextEditingController` のリスナー方式で、変換確定（composing クリア）後にのみフィルタを反映。変換中の中間状態（`t → te → テ …`）では発火しない
- **0件表示**: ヒット0件時は中央に「該当するマニュアルが見つかりませんでした」
- **クリア挙動**: ✕押下で全件表示に戻し、フォーカスは検索ボックスに維持
- **a11y**: `Semantics(label: 'マニュアル検索')`
- **ソート**: 元の表示順を維持（フィルタのみ・並べ替えなし）

## 動作確認
ローカルの Flutter Web（Chrome）で以下を確認済み:

- [x] `テスト` 入力 → テスト1/2/3 のみ表示
- [x] `ng`（半角小文字）→ `NG` がヒット（大文字小文字を区別しない）
- [x] 日本語IME入力で、変換確定後に絞り込みが反映される
- [x] ヒット0件（例 `zzz`）→ 未ヒットメッセージ表示
- [x] ✕クリア → 全件に戻り、フォーカス維持
- [x] `flutter analyze` パス（本ファイルは指摘なし）

## 補足 / レビュー観点
- 検証は **Flutter Web（Chrome）のみ**です。仕様のターゲットである **iOS Safari / And動は未検証のため、可能なら実機確認をお願いします（IMEの `composing`挙動はプラットフォーム差が出やすいため）。
- 本PRは **`manual_list_page.dart` の1ファイルのみ**の変更です。
- （別件）動作確認中に、ログインAPI `/mail_auth/signin` が 500 を返す事象を確認しました。本PRのスコープ外なので、必要なら別Issueで対応を提案します。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 起動時にマニュアル一覧を非同期取得し、読み込み中は専用画面を表示します。
  * 待機画面の表示文言を切り替え可能にしました。
* **改善**
  * 検索は200msデバウンスし、日本語入力の未確定文字は確定後に反映します。
  * タスク名で部分一致検索し、該当なし時はメッセージを表示します。
  * 読み込み失敗時は「再読み込み」付きのエラービューを表示します。
  * 一覧項目タップで関連URLを開く動作は維持します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->