### PR TITLE
test: compareTimeStringsのゴールデンテストを追加（フェーズ1お手本PR）

### DIFF
--- a/api/lib/usecase/shift_usecase_test.go
+++ b/api/lib/usecase/shift_usecase_test.go
@@ -1,0 +1,85 @@
+package usecase
+
+import "testing"
+
+// TestCompareTimeStrings は compareTimeStrings のゴールデンテスト。
+// 期待値は docs/development/test-design/phase1-pure-functions.md の
+// compareTimeStrings セクションに記載のケース表と、実行による裏取り結果に基づく。
+// 「要判断」の付いたケースは現状の挙動をそのまま固定したもので、
+// 挙動の是非は issue #418 で判断する。
+func TestCompareTimeStrings(t *testing.T) {
+	u := &shiftUseCase{}
+
+	cases := []struct {
+		name  string
+		time1 string
+		time2 string
+		want  int
+	}{
+		{
+			name:  "桁数が異なる時刻の数値比較",
+			time1: "8:00", time2: "10:00",
+			want: -1,
+		},
+		{
+			name:  "逆順で正の値を返す",
+			time1: "10:00", time2: "8:00",
+			want: 1,
+		},
+		{
+			name:  "同一時刻は等価",
+			time1: "9:15", time2: "9:15",
+			want: 0,
+		},
+		{
+			name:  "同時間帯での分単位の差",
+			time1: "9:15", time2: "9:30",
+			want: -1,
+		},
+		{
+			name:  "ゼロ値時刻と一日の最大時刻",
+			time1: "0:00", time2: "23:59",
+			want: -1,
+		},
+		{
+			name:  "ゼロパディング表記の同値性",
+			time1: "08:05", time2: "8:05",
+			want: 0,
+		},
+		{
+			name:  "非正規化の分表記は換算後に等価",
+			time1: "1:30", time2: "0:90",
+			want: 0,
+		},
+		{
+			// 要判断（issue #418）: 空文字列はガード節に入り「等価」扱いになる。
+			// sort.Slice は非安定ソートのため、異常な StartTime を持つ
+			// ShiftCard の並び順が実行のたびに変わりうる。
+			name:  "空文字列は正当な時刻とも等価扱い（要判断: issue #418）",
+			time1: "", time2: "10:00",
+			want: 0,
+		},
+		{
+			name:  "コロンが2個以上の書式は等価扱い",
+			time1: "10:00:00", time2: "9:00",
+			want: 0,
+		},
+		{
+			// 要判断（issue #418）: strconv.Atoi のエラーが黙殺され、
+			// 非数値の時分が 0:00 として扱われる。上の「空文字列」ケースとは
+			// 異なり「等価」ではなく「最小値」として扱われる非対称な挙動。
+			name:  "非数値の時分は暗黙に0:00扱い（要判断: issue #418）",
+			time1: "aa:bb", time2: "8:00",
+			want: -1,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := u.compareTimeStrings(c.time1, c.time2)
+			if got != c.want {
+				t.Errorf("compareTimeStrings(%q, %q) = %d, want %d", c.time1, c.time2, got, c.want)
+			}
+		})
+	}
+}

--- a/api/lib/usecase/shift_usecase_test.go
+++ b/api/lib/usecase/shift_usecase_test.go
@@ -2,7 +2,7 @@ package usecase
 
 import "testing"
 
-// TestCompareTimeStrings は compareTimeStrings のゴールデンテスト。
+// compareTimeStrings のゴールデンテスト。
 // 期待値は docs/development/test-design/phase1-pure-functions.md の
 // compareTimeStrings セクションに記載のケース表と、実行による裏取り結果に基づく。
 // 「要判断」の付いたケースは現状の挙動をそのまま固定したもので、
@@ -60,7 +60,10 @@ func TestCompareTimeStrings(t *testing.T) {
 			want: 0,
 		},
 		{
-			name:  "コロンが2個以上の書式は等価扱い",
+			// 要判断（issue #418）: コロンが2個以上の入力も、空文字列と同じ
+			// ガード節（len(parts) != 2）を通り「等価」扱いになる。上の
+			// 「空文字列」ケースと同一の論点（issue #418 の論点1）。
+			name:  "コロンが2個以上の書式は等価扱い（要判断: issue #418）",
 			time1: "10:00:00", time2: "9:00",
 			want: 0,
 		},


### PR DESCRIPTION
## 概要

フェーズ1（依存ゼロの純関数テスト）の最初の実装。`compareTimeStrings`（`api/lib/usecase/shift_usecase.go:509`）に**ゴールデンテスト**（今のコードが実際に返している値を、そのまま「正解」としてテストに固定する手法。仕様書ではなく現状の動作を基準にする）を追加する。api配下で初めての`_test.go`ファイルであり、以降メンバーが残り7関数（#420〜#426）を実装する際の**お手本**を兼ねる。

## 背景（なぜこの実装なのか）

このPRはお手本を兼ねるため、機械的な変更内容だけでなく設計判断の理由も残す。

### なぜこの関数を最初の実装対象に選んだか

フェーズ1（純関数、単体テスト）は依存先を偽装する必要が無く、誰の環境で実行しても結果が変わらない。一方フェーズ2（repository、実DB統合）は環境に結果が左右されやすい（このPRに先立つ調査で、ローカルに残っていた古いDBボリュームのせいで誤った挙動を観測しかけたことがあった）。メンバーへの最初の割り振りには環境依存の無いフェーズ1が適しており、その中でも戻り値が`int`のみで比較しやすく、要判断も少ない`compareTimeStrings`を選んだ。

### なぜ期待値がこの数字なのか

`want`の値は、コードを読んで「こう動くべき」と推測したものではない。設計書（`docs/development/test-design/phase1-pure-functions.md`）作成時に、実際に使い捨てテストを実行し、今のコードが実際に返す値を観察してから記録したもの（ゴールデンテストの定義どおり）。たとえば`"aa:bb"`のケースが`-1`（`0:00`扱い）になるのは、`strconv.Atoi`のエラーが`_`で握りつぶされる現状のコードをそのまま反映した結果であり、「本来こうあるべき」という設計上の意図ではない。

### なぜ要判断2件をこのPRの中で直さなかったか

**要判断**とは、実装時に見つかった「これは仕様として固定してよい挙動か、それともバグとして直すべきか」がまだ決まっていない箇所のこと。「異常な入力を0扱いにすべきか、エラーにすべきか」は、`compareTimeStrings`単体を読むだけでは決められず、呼び出し元の`sort.Slice`（`shift_usecase.go:423-425`）や、その先のシフトデータの整合性まで調査が要る。テストを書くPRとバグを直すPRを混ぜると、後から見た人が「これは現状を記録しただけか、意図的に挙動を変えたのか」をdiffから判断できなくなる。そのため、判断が必要な部分は現状の挙動をそのまま固定した上で、判断そのものを別issue（#418）に切り出した。

## 変更内容

`api/lib/usecase/shift_usecase_test.go` を新規追加。`docs/development/test-design/phase1-pure-functions.md`の`compareTimeStrings`セクションに載っている10ケースを、そのまま**テーブル駆動テスト**（入力と期待値の組み合わせをスライスで列挙し、1つのループで全パターンを検証するGoの定番の書き方）として実装した。

- ファイル配置: 対象ファイルと同じディレクトリに `<対象ファイル名>_test.go`
- パッケージ: `package usecase`（テスト対象と同一パッケージ）。`compareTimeStrings`は小文字始まりの**unexported**な関数で、Goでは同じパッケージ内のコードからしか呼び出せない。そのためテストファイルも`package usecase`にして、直接呼べるようにしている
- レシーバ: `compareTimeStrings`は`func (a *shiftUseCase) compareTimeStrings(...)`という、構造体のメソッドとして定義されている（この構造体を**レシーバ**と呼ぶ）。ただし関数の中身はレシーバ`a`のフィールドを一切参照していない純関数なので、テストでは中身が空の**ゼロ値**`&shiftUseCase{}`を作ってメソッドを呼び出すだけで済む（DBやSlackへの接続を用意する必要が無い）
- ケース表の`name`/`time1`/`time2`/`want`をそのまま構造体スライスにし、`t.Run`でサブテスト化

要判断2件は、設計書の記載どおり現状挙動をそのまま期待値にし、コメントで issue #418 にリンクした。

## 動作確認

```console
$ go test ./lib/usecase/... -run TestCompareTimeStrings -v -count=1
--- PASS: TestCompareTimeStrings (0.00s)
    --- PASS: TestCompareTimeStrings/桁数が異なる時刻の数値比較 (0.00s)
    --- PASS: TestCompareTimeStrings/逆順で正の値を返す (0.00s)
    --- PASS: TestCompareTimeStrings/同一時刻は等価 (0.00s)
    --- PASS: TestCompareTimeStrings/同時間帯での分単位の差 (0.00s)
    --- PASS: TestCompareTimeStrings/ゼロ値時刻と一日の最大時刻 (0.00s)
    --- PASS: TestCompareTimeStrings/ゼロパディング表記の同値性 (0.00s)
    --- PASS: TestCompareTimeStrings/非正規化の分表記は換算後に等価 (0.00s)
    --- PASS: TestCompareTimeStrings/空文字列は正当な時刻とも等価扱い（要判断: issue #418） (0.00s)
    --- PASS: TestCompareTimeStrings/コロンが2個以上の書式は等価扱い (0.00s)
    --- PASS: TestCompareTimeStrings/非数値の時分は暗黙に0:00扱い（要判断: issue #418） (0.00s)
PASS
```

`go vet ./lib/usecase/...`・`golangci-lint run ./lib/usecase/...` ともに指摘なし。

## 関連

- 親issue: #404（フェーズ1）
- 要判断: #418
- 設計書: `docs/development/test-design/phase1-pure-functions.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * 時刻文字列の比較処理に対するテストを追加しました。
  * 時刻の大小・同値性、ゼロパディング、桁数や分の違い、無効な形式など、さまざまなケースを検証します。
  * 現在の比較結果をテストで固定し、今後の変更による不具合を検出しやすくしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->