### PR TITLE
fix: mail_auth の Scan で slack_user_id が NULL だと失敗する不具合を修正

### DIFF
--- a/api/lib/usecase/mail_auth_usecase.go
+++ b/api/lib/usecase/mail_auth_usecase.go
@@ -54,6 +54,9 @@ func (u *mailAuthUseCase) SignIn(c context.Context, studentNumber string, passwo
 	); err != nil {
 		return entity.LoginUser{}, errors.Wrapf(err, "ユーザーの取得に失敗: %v", err)
 	}
+	if slackUserID.Valid {
+		user.SlackUserID = slackUserID.String
+	}
 
 	// パスワードがあっているか確認
 	password = strings.ReplaceAll(password, " ", "")
@@ -106,6 +109,9 @@ func (u *mailAuthUseCase) WebSignUp(c context.Context, name string, mail string,
 	if err != nil {
 		return token, err
 	}
+	if slackUserID.Valid {
+		user.SlackUserID = slackUserID.String
+	}
 
 	// トークン発行
 	accessToken, err := _makeRandomStr(10)
@@ -145,6 +151,9 @@ func (u *mailAuthUseCase) WebSignIn(c context.Context, studentNumber string, pas
 	)
 	if err != nil {
 		return token, err
+	}
+	if slackUserID.Valid {
+		user.SlackUserID = slackUserID.String
 	}
 
 	// パスワードがあっているか確認

--- a/api/lib/usecase/mail_auth_usecase.go
+++ b/api/lib/usecase/mail_auth_usecase.go
@@ -3,6 +3,7 @@ package usecase
 import (
 	"context"
 	"crypto/rand"
+	"database/sql"
 	"fmt"
 	"strconv"
 	"strings"
@@ -35,6 +36,7 @@ func (u *mailAuthUseCase) SignIn(c context.Context, studentNumber string, passwo
 
 	// メールアドレスの存在確認
 	row := u.userRep.FindByStudentNumber(c, studentNumber)
+	var slackUserID sql.NullString
 	if err := row.Scan(
 		&user.ID,
 		&user.Name,
@@ -48,7 +50,7 @@ func (u *mailAuthUseCase) SignIn(c context.Context, studentNumber string, passwo
 		&user.Password,
 		&user.CreatedAt,
 		&user.UpdatedAt,
-		&user.SlackUserID,
+		&slackUserID,
 	); err != nil {
 		return entity.LoginUser{}, errors.Wrapf(err, "ユーザーの取得に失敗: %v", err)
 	}
@@ -85,6 +87,7 @@ func (u *mailAuthUseCase) WebSignUp(c context.Context, name string, mail string,
 	if err != nil {
 		return token, err
 	}
+	var slackUserID sql.NullString
 	err = row.Scan(
 		&user.ID,
 		&user.Name,
@@ -98,7 +101,7 @@ func (u *mailAuthUseCase) WebSignUp(c context.Context, name string, mail string,
 		&user.Password,
 		&user.CreatedAt,
 		&user.UpdatedAt,
-		&user.SlackUserID,
+		&slackUserID,
 	)
 	if err != nil {
 		return token, err
@@ -124,6 +127,7 @@ func (u *mailAuthUseCase) WebSignIn(c context.Context, studentNumber string, pas
 
 	// メールアドレスの存在確認
 	row := u.userRep.FindByStudentNumber(c, studentNumber)
+	var slackUserID sql.NullString
 	err := row.Scan(
 		&user.ID,
 		&user.Name,
@@ -137,7 +141,7 @@ func (u *mailAuthUseCase) WebSignIn(c context.Context, studentNumber string, pas
 		&user.Password,
 		&user.CreatedAt,
 		&user.UpdatedAt,
-		&user.SlackUserID,
+		&slackUserID,
 	)
 	if err != nil {
 		return token, err


### PR DESCRIPTION
## 概要

`users.slack_user_id` は NULL 許容カラムだが、`mail_auth_usecase.go` の `SignIn` / `WebSignUp` / `WebSignIn` が `SELECT *` の結果を素の `string` フィールドへ直接 Scan していたため、`slack_user_id` 未設定のユーザーはログイン・新規登録（`/mail_auth/signin`, `/mail_auth/web_signin`, `/mail_auth/web_signup`）が常に失敗していた。

パスワードの正誤に関係なく、`slack_user_id` が NULL である限り Scan 自体がエラーになる。

## 原因

```go
// api/lib/usecase/mail_auth_usecase.go（修正前）WebSignIn
row := u.userRep.FindByStudentNumber(c, studentNumber)
err := row.Scan(
    ...,
    &user.SlackUserID, // ← entity.User.SlackUserID は string。DBがNULLだとここでScanエラー
)
```

同じクラスのバグは issue #353 で `GetUsersByShift` にも発生しており、そちらは `shift_repository.go` 側の `COALESCE(u.slack_user_id, '')` で解決済み。`user_usecase.go` / `rescue_unified_usecase.go` は `sql.NullString` 経由で対応済みだったが、`mail_auth_usecase.go` の3箇所だけ対応が漏れていた。

## 修正内容

`user_usecase.go` 等と同じ `sql.NullString` 経由のScanパターンに統一。この3関数では `entity.User` を返り値に含めず（`LoginUser`/`Token` のみ返す）`SlackUserID` を読むコードが無いため、値の書き戻しは行わず、Scan失敗を防ぐことだけを行っている。

## 検証

- `go build ./...` / `go vet ./...` 通過
- ローカルdocker環境（`docker-compose.yml`）で実データに対して確認
  - `slack_user_id` が空の既存ユーザー（student_number `23103285`）で `POST /mail_auth/web_signin` → 修正前は 500、修正後は 200 + accessToken を確認
  - 新規サインアップ（`POST /mail_auth/web_signup`）→ 200 + accessToken を確認（検証用データは削除済み）

Close #428


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **不具合修正**
  * SlackユーザーIDが未設定（NULL）のユーザーでも、サインインやアカウント登録時にエラーが発生しないよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->