### PR TITLE
fix: govetのunusedwriteをCI lintに追加し未使用なSlackUserID書き戻しを削除

### DIFF
--- a/api/.golangci.yml
+++ b/api/.golangci.yml
@@ -8,6 +8,9 @@ linters:
     revive:
       severity: warning
     gosec: {}
+    govet:
+      enable:
+        - unusedwrite
 
 issues:
   max-same-issues: 0

--- a/api/lib/usecase/mail_auth_usecase.go
+++ b/api/lib/usecase/mail_auth_usecase.go
@@ -54,9 +54,6 @@ func (u *mailAuthUseCase) SignIn(c context.Context, studentNumber string, passwo
 	); err != nil {
 		return entity.LoginUser{}, errors.Wrapf(err, "ユーザーの取得に失敗: %v", err)
 	}
-	if slackUserID.Valid {
-		user.SlackUserID = slackUserID.String
-	}
 
 	// パスワードがあっているか確認
 	password = strings.ReplaceAll(password, " ", "")
@@ -109,9 +106,6 @@ func (u *mailAuthUseCase) WebSignUp(c context.Context, name string, mail string,
 	if err != nil {
 		return token, err
 	}
-	if slackUserID.Valid {
-		user.SlackUserID = slackUserID.String
-	}
 
 	// トークン発行
 	accessToken, err := _makeRandomStr(10)
@@ -151,9 +145,6 @@ func (u *mailAuthUseCase) WebSignIn(c context.Context, studentNumber string, pas
 	)
 	if err != nil {
 		return token, err
-	}
-	if slackUserID.Valid {
-		user.SlackUserID = slackUserID.String
 	}
 
 	// パスワードがあっているか確認

--- a/api/lib/usecase/user_usecase.go
+++ b/api/lib/usecase/user_usecase.go
@@ -367,9 +367,6 @@ func (u *userUseCase) UpdateUsersFromGAS(ctx context.Context, req entity.UserCha
 		var user entity.User
 		var slackUserID sql.NullString
 		if err := userRow.Scan(&user.ID, &user.Name, &user.Mail, &user.GradeID, &user.DepartmentID, &user.BureauID, &user.RoleID, &user.StudentNumber, &user.Tel, &user.Password, &user.CreatedAt, &user.UpdatedAt, &slackUserID); err == nil {
-			if slackUserID.Valid {
-				user.SlackUserID = slackUserID.String
-			}
 			// ユーザーが存在すれば更新
 			if err := u.userRep.Update(ctx, strconv.Itoa(user.ID), change.Name, user.Mail, gradeID, departmentID, bureauID, strconv.Itoa(user.RoleID), studentNumber, tel, user.Password); err != nil {
 				return errors.Wrapf(err, "ユーザー更新失敗: %v", change.Name)


### PR DESCRIPTION
# 対応Issue
resolve #430

# 概要
VS Codeのgopls（エディタ）は `unused write to field SlackUserID` を4件検出するが、CIの `golangci-lint`（`.github/workflows/go-lint.yml`）は0件だった。原因はgoplsとgolangci-lintがそれぞれ別々にどのgovet解析パスをデフォルト有効にするか決めているためで、`unusedwrite` はgolangci-lint側で未設定だった。

`govet.enable-all: true` で試すと61件（`unusedwrite` 4件・`shadow` 12件・`fieldalignment` 45件）検出されたが、`shadow`/`fieldalignment` はノイズ対効果が悪く見送り、実質バグ相当かつ誤検知ゼロの `unusedwrite` のみをCIに追加した。

`notification_usecase.go`（L248→L309）では `user.SlackUserID` を詰めて `SendMessage` に渡す正しい使用例が既にあり、今回の4件（`mail_auth_usecase.go` の SignIn/WebSignUp/WebSignIn、`user_usecase.go` のCSV一括更新）はこのパターンを機械的に横展開した際の残骸と確認済み。ログイン/サインアップ/CSV更新のいずれもSlack通知を送らない設計であり、書き戻した値は後続で一度も読まれていなかった。

- `api/.golangci.yml` に `govet.enable: [unusedwrite]` を追加
- 上記4箇所の未使用な書き戻しブロックを削除（NULLスキャン失敗回避用の `sql.NullString` 受け取り自体は維持）

# 画面スクリーンショット等
- `URL`
スクリーンショット

# テスト項目
- `cd api && golangci-lint run ./...` が `0 issues.` になること
- `go build ./...` が通ること
- `docker compose run --rm api go test ./...` が既存同様 `[no test files]` で正常終了すること

# 備考
`shadow`（12件）・`fieldalignment`（45件）は今回スコープ外。将来再検討する場合の内訳として issue に記録済み。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency when processing user sign-ins, registrations, and profile updates involving linked Slack account information.
  * Prevented outdated Slack account details from being carried forward during user data synchronization.

* **Chores**
  * Enhanced static analysis checks to identify additional potential code issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->