### PR TITLE
[feat]シフトカードのデザイン変更

### DIFF
--- a/mobile/lib/pages/my_shift_page.dart
+++ b/mobile/lib/pages/my_shift_page.dart
@@ -689,6 +689,7 @@ class _MyShiftPageState extends State<MyShiftPage>
                     children: [
                       ShiftCard(
                         data: data,
+                        userID: _userID,
                         isNew: isNew,
                         onOpened: () {
                           // トグルを開いたときの処理

--- a/mobile/lib/pages/my_shift_page.dart
+++ b/mobile/lib/pages/my_shift_page.dart
@@ -688,6 +688,7 @@ class _MyShiftPageState extends State<MyShiftPage>
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       ShiftCard(
+                        key: ValueKey(cardKey),
                         data: data,
                         userID: _userID,
                         isNew: isNew,

--- a/mobile/lib/widgets/shift_card.dart
+++ b/mobile/lib/widgets/shift_card.dart
@@ -305,7 +305,7 @@ class _ShiftCardMenuPanel extends PopupMenuEntry<_ShiftCardMenuAction> {
   const _ShiftCardMenuPanel();
 
   @override
-  double get height => 138;
+  double get height => 97;
 
   @override
   bool represents(_ShiftCardMenuAction? value) => false;
@@ -315,7 +315,6 @@ class _ShiftCardMenuPanel extends PopupMenuEntry<_ShiftCardMenuAction> {
 }
 
 class _ShiftCardMenuPanelState extends State<_ShiftCardMenuPanel> {
-  _ShiftCardMenuAction? _hoveredAction;
   _ShiftCardMenuAction? _pressedAction;
 
   @override
@@ -344,17 +343,13 @@ class _ShiftCardMenuPanelState extends State<_ShiftCardMenuPanel> {
                 _ShiftCardMenuRow(
                   action: _ShiftCardMenuAction.members,
                   label: '担当者一覧',
-                  isHovered: _hoveredAction == _ShiftCardMenuAction.members,
                   isPressed: _pressedAction == _ShiftCardMenuAction.members,
-                  onHoverChanged: _handleHoverChanged,
                   onPressChanged: _handlePressChanged,
                 ),
                 _ShiftCardMenuRow(
                   action: _ShiftCardMenuAction.review,
                   label: 'レビューを書く',
-                  isHovered: _hoveredAction == _ShiftCardMenuAction.review,
                   isPressed: _pressedAction == _ShiftCardMenuAction.review,
-                  onHoverChanged: _handleHoverChanged,
                   onPressChanged: _handlePressChanged,
                 ),
                 const SizedBox(height: 8.0),
@@ -364,12 +359,6 @@ class _ShiftCardMenuPanelState extends State<_ShiftCardMenuPanel> {
         ),
       ),
     );
-  }
-
-  void _handleHoverChanged(_ShiftCardMenuAction action, bool isHovered) {
-    setState(() {
-      _hoveredAction = isHovered ? action : null;
-    });
   }
 
   void _handlePressChanged(_ShiftCardMenuAction action, bool isPressed) {
@@ -382,19 +371,14 @@ class _ShiftCardMenuPanelState extends State<_ShiftCardMenuPanel> {
 class _ShiftCardMenuRow extends StatelessWidget {
   final _ShiftCardMenuAction action;
   final String label;
-  final bool isHovered;
   final bool isPressed;
-  final void Function(_ShiftCardMenuAction action, bool isHovered)
-      onHoverChanged;
   final void Function(_ShiftCardMenuAction action, bool isPressed)
       onPressChanged;
 
   const _ShiftCardMenuRow({
     required this.action,
     required this.label,
-    required this.isHovered,
     required this.isPressed,
-    required this.onHoverChanged,
     required this.onPressChanged,
   });
 
@@ -404,7 +388,6 @@ class _ShiftCardMenuRow extends StatelessWidget {
       button: true,
       label: label,
       child: InkWell(
-        onHover: (hovering) => onHoverChanged(action, hovering),
         onTapDown: (_) => onPressChanged(action, true),
         onTapCancel: () => onPressChanged(action, false),
         onTap: () async {

--- a/mobile/lib/widgets/shift_card.dart
+++ b/mobile/lib/widgets/shift_card.dart
@@ -271,25 +271,21 @@ class _ShiftCardMoreButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MouseRegion(
-      cursor: SystemMouseCursors.click,
-      child: GestureDetector(
-        behavior: HitTestBehavior.opaque,
-        onTapDown: (_) => onPressed(_menuPosition(context)),
-        child: DecoratedBox(
-          decoration: BoxDecoration(
-            color: Colors.transparent,
-            borderRadius: BorderRadius.circular(AppBorderRadius.normal),
-          ),
-          child: Padding(
-            padding: const EdgeInsets.all(8.0),
-            child: Icon(
-              Icons.more_vert,
-              color: AppColors.textBlack,
-              size: 24,
-            ),
-          ),
+    return IconButton(
+      onPressed: () => onPressed(_menuPosition(context)),
+      tooltip: 'メニューを開く',
+      padding: const EdgeInsets.all(8.0),
+      constraints: const BoxConstraints(),
+      style: IconButton.styleFrom(
+        backgroundColor: Colors.transparent,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(AppBorderRadius.normal),
         ),
+      ),
+      icon: const Icon(
+        Icons.more_vert,
+        color: AppColors.textBlack,
+        size: 24,
       ),
     );
   }
@@ -403,20 +399,22 @@ class _ShiftCardMenuRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MouseRegion(
-      cursor: SystemMouseCursors.click,
-      onEnter: (_) => onHoverChanged(action, true),
-      onExit: (_) => onHoverChanged(action, false),
-      child: GestureDetector(
-        behavior: HitTestBehavior.opaque,
+    return Semantics(
+      button: true,
+      label: label,
+      child: InkWell(
+        onHover: (hovering) => onHoverChanged(action, hovering),
         onTapDown: (_) => onPressChanged(action, true),
         onTapCancel: () => onPressChanged(action, false),
-        onTapUp: (_) async {
+        onTap: () async {
           await Future<void>.delayed(const Duration(milliseconds: 120));
           if (context.mounted) {
             Navigator.pop(context, action);
           }
         },
+        splashFactory: NoSplash.splashFactory,
+        highlightColor: Colors.transparent,
+        hoverColor: Colors.transparent,
         child: Container(
           width: double.infinity,
           height: 40,

--- a/mobile/lib/widgets/shift_card.dart
+++ b/mobile/lib/widgets/shift_card.dart
@@ -1,316 +1,481 @@
 import 'package:seeft_mobile/configs/importer.dart';
 import 'package:seeft_mobile/widgets/manual_viewer.dart';
-import 'package:url_launcher/url_launcher.dart';
 import 'package:seeft_mobile/widgets/new_badge.dart';
+import 'package:seeft_mobile/widgets/review_bottom_sheet.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 // シフトカードのウィジェット
 class ShiftCard extends StatelessWidget {
   final ShiftCardData data;
+  final int userID;
   final bool isNew;
   final VoidCallback? onOpened;
 
   const ShiftCard({
     super.key,
     required this.data,
+    required this.userID,
     this.isNew = false,
     this.onOpened,
   });
-  
-  // リンクを開くための非同期メソッドを定義
-  Future<void> _launchManualUrl(String url) async {
-    // 開きたいURLをUriオブジェクトに変換
-    final Uri uri = Uri.parse(url);
-
-    // launchUrlを実行
-    if (!await launchUrl(uri, mode: LaunchMode.externalApplication)) {  // ここで外部アプリで開くように指定
-      // URLが開けなかった場合のエラー処理
-      throw Exception('Could not launch $uri');
-    }
-  }
 
   @override
   Widget build(BuildContext context) {
     return Card(
-      margin:EdgeInsets.zero,
+      margin: EdgeInsets.zero,
       shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(8.0), // 角丸を設定
-        side: BorderSide(
-          color: AppColors.grayLight, // 枠線の色
-          width: 1.0, // 枠線の太さ
+        borderRadius: BorderRadius.circular(AppBorderRadius.normal),
+        side: const BorderSide(
+          color: AppColors.grayLight,
+          width: 1.0,
         ),
       ),
       elevation: 0.5,
       shadowColor: null,
-      color: AppColors.base, // 背景色を設定
+      color: AppColors.base,
       child: Padding(
         padding: const EdgeInsets.all(8.0),
         child: Column(
           mainAxisSize: MainAxisSize.min,
-          mainAxisAlignment: MainAxisAlignment.start,
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            // 時刻とマニュアルを開くボタン
             Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
-                // 時刻の表示
                 Row(
                   children: [
                     const Icon(
                       Icons.access_time,
                       color: AppColors.textBlack,
-                      size: 16
+                      size: 16,
                     ),
                     const SizedBox(width: 2.0),
                     Text(
-                      "${data.startTime}〜${data.endTime}",
+                      '${data.startTime}~${data.endTime}',
                       style: const TextStyle(
                         fontSize: AppFontSizes.sm,
-                        color: AppColors.textBlack
+                        color: AppColors.textBlack,
                       ),
                     ),
                   ],
                 ),
-                // マニュアルを開くボタン
-                _manualButton(url: data.url),
+                _cardMenu(context),
               ],
             ),
-            // タスク名とNewバッジの表示
             Row(
               children: [
+                if (isNew) ...[
+                  const NewBadge(),
+                  const SizedBox(width: 4.0),
+                ],
                 Flexible(
                   child: Text(
                     data.taskName.toString(),
                     style: const TextStyle(
                       fontSize: AppFontSizes.md,
-                      color: AppColors.textBlack, 
-                      fontWeight: FontWeight.bold
+                      color: AppColors.textBlack,
+                      fontWeight: FontWeight.bold,
                     ),
                     textAlign: TextAlign.left,
                   ),
                 ),
-                if (isNew) ...[
-                  const SizedBox(width: 8.0),
-                  const NewBadge(),
-                ],
               ],
             ),
             const SizedBox(height: 6.0),
             const Divider(
               height: 1,
-              color: AppColors.grayLight, // 区切り線の色
+              color: AppColors.grayLight,
             ),
-            // 集合場所とトグル
-            Theme(
-              data: Theme.of(context).copyWith(dividerColor: Colors.transparent), // 区切り線の色を透明に
-              child: ExpansionTile(
-                tilePadding: EdgeInsets.zero,
-                iconColor: AppColors.textBlack, // アイコンの色を変更
-                minTileHeight: 0, // タイルの高さを最小に
-                onExpansionChanged: (expanded) {
-                  // トグルを開いたときにコールバックを呼ぶ
-                  if (expanded && isNew && onOpened != null) {
-                    onOpened!();
-                  }
-                },
-                // 集合場所の表示
-                title: Row(
-                  children: [
-                    const Icon(
-                      Icons.location_on_outlined, 
-                      color: AppColors.textBlack,
-                      size: 16
-                    ),
-                    const SizedBox(width: 2.0),
-                    Text(
-                      data.place,
-                      style: const TextStyle(
-                        fontSize: AppFontSizes.sm,
-                        color: AppColors.textBlack
-                      ),
-                    ),
-                  ],
+            const SizedBox(height: 6.0),
+            Row(
+              children: [
+                const Icon(
+                  Icons.location_on_outlined,
+                  color: AppColors.textBlack,
+                  size: 16,
                 ),
-                // トグルが展開されたときの内容
-                children: <Widget>[
-                  _buildSection(
-                    title: '【集合場所】',
-                    content: [data.place]
+                const SizedBox(width: 2.0),
+                Flexible(
+                  child: Text(
+                    data.place,
+                    style: const TextStyle(
+                      fontSize: AppFontSizes.sm,
+                      color: AppColors.textBlack,
+                    ),
                   ),
-                  _buildManualSection(
-                    title: '【マニュアル】',
-                    url: data.url != '' ? data.url : null
-                  ),
-                  _buildSection(
-                    title: '【困った時は】',
-                    content: [
-                      '以下の順に対応してください。',
-                      '1. マニュアルを確認してください。',
-                      '2. 近くの人や近くの先輩に相談してください。',
-                      '3. 「緊急事対応」ページから本部に連絡してください。',
-                    ],
-                  ),
-                  _buildSection(
-                    title: '【担当者の一覧】',
-                    content: [
-                      for (var member in data.shiftMembers)
-                        '${member.sTime}〜${member.eTime}\n${member.members.map((m) => '(${m.bureau}${m.grade}) ${m.name}').join(', ')}',
-                    ],
-                  ),
-                  _buildSection(
-                    title: '【前の時間の担当者の一覧】',
-                    content: [
-                      if (data.beforeMembers.members.isNotEmpty)
-                        '${data.beforeMembers.sTime}〜${data.beforeMembers.eTime}\n${data.beforeMembers.members.map((m) => '(${m.bureau}${m.grade}) ${m.name}').join(', ')}'
-                      else
-                        '前の時間の担当者はいません',
-                    ],
-                  ),
-                  _buildSection(
-                    title: '【次の時間の担当者の一覧】',
-                    content: [
-                      if (data.afterMembers.members.isNotEmpty)
-                        '${data.afterMembers.sTime}〜${data.afterMembers.eTime}\n${data.afterMembers.members.map((m) => '(${m.bureau}${m.grade}) ${m.name}').join(', ')}'
-                      else
-                        '次の時間の担当者はいません',
-                    ],
-                  ),
-                ],
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-  // マニュアルボタン
-  Widget _manualButton({
-    required String url,
-  }) {
-    final bool isDisabled = url.isEmpty;  // マニュアルがない場合は無効化する
-    return ElevatedButton.icon(
-      onPressed: isDisabled ? null : () => _launchManualUrl(url), // マニュアルがあればタップで開く
-      icon: Icon(
-        Icons.quiz_outlined,
-        size: 16,
-        color: isDisabled ? AppColors.grayDark : AppColors.textWhite,
-      ),
-      label: Text(
-        isDisabled ? 'マニュアルなし' : 'マニュアル',
-        style: TextStyle(
-          fontSize: AppFontSizes.sm,
-          color: isDisabled ? AppColors.grayDark : AppColors.textWhite,
-        ),
-      ),
-      style: ElevatedButton.styleFrom(
-        backgroundColor: isDisabled ? AppColors.grayLight : AppColors.link,
-        padding: const EdgeInsets.symmetric(
-          vertical: 4.0,
-          horizontal: 8.0
-        ),
-        elevation: 0,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(100.0),
-        ),
-        // 横幅を広げるための設定
-        // minimumSize: Size(double.infinity, 40),
-      ),
-    );
-  }
-  
-  // 各セクションのUIを生成するヘルパーメソッド
-  Widget _buildSection({
-    required String title, 
-    required List<String> content
-  }) {
-    return Padding(
-      padding: const EdgeInsets.only(top: 8.0, bottom: 8.0),
-      child: Align(
-        alignment: Alignment.centerLeft,
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              title,
-              style: const TextStyle(
-                fontSize: AppFontSizes.xs,
-                color: AppColors.textBlack,
-                fontWeight: FontWeight.bold
-              ),
+                ),
+              ],
             ),
             const SizedBox(height: 4.0),
-            ...content.map((line) => Text(
-              line, 
-              style: const TextStyle(
-                fontSize: AppFontSizes.xs, 
-                color: AppColors.textBlack,
-                height: 1.5 // 行間を調整
-              )
-            )),
+            _ManualToggle(
+              url: data.url,
+              onOpened: () {
+                if (isNew && onOpened != null) {
+                  onOpened!();
+                }
+              },
+            ),
           ],
         ),
       ),
     );
   }
-  // マニュアルセクションのUIを生成するヘルパーメソッド
-  Widget _buildManualSection({
+
+  Widget _cardMenu(BuildContext context) {
+    return Builder(
+      builder: (menuContext) {
+        return _ShiftCardMoreButton(
+          onPressed: (position) => _showCardMenu(menuContext, position),
+        );
+      },
+    );
+  }
+
+  Future<void> _showCardMenu(BuildContext context, Offset position) async {
+    final overlay = Overlay.of(context).context.findRenderObject() as RenderBox;
+    final action = await showMenu<_ShiftCardMenuAction>(
+      context: context,
+      color: Colors.transparent,
+      elevation: 0,
+      shadowColor: Colors.transparent,
+      surfaceTintColor: Colors.transparent,
+      constraints: const BoxConstraints.tightFor(width: 212),
+      menuPadding: EdgeInsets.zero,
+      position: RelativeRect.fromRect(
+        Rect.fromLTWH(position.dx, position.dy, 0, 0),
+        Offset.zero & overlay.size,
+      ),
+      items: const [
+        _ShiftCardMenuPanel(),
+      ],
+    );
+
+    if (action == null) return;
+    switch (action) {
+      case _ShiftCardMenuAction.members:
+        if (isNew && onOpened != null) {
+          onOpened!();
+        }
+        if (context.mounted) {
+          _showMembersDialog(context);
+        }
+        break;
+      case _ShiftCardMenuAction.review:
+        if (context.mounted) {
+          ReviewBottomSheet.show(context, data.taskName, userID);
+        }
+        break;
+    }
+  }
+
+  void _showMembersDialog(BuildContext context) {
+    showDialog(
+      context: context,
+      barrierColor: Colors.black.withValues(alpha: 0.2),
+      builder: (context) {
+        return AlertDialog(
+          backgroundColor: AppColors.base,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(AppBorderRadius.normal),
+          ),
+          contentPadding: const EdgeInsets.all(16.0),
+          content: SingleChildScrollView(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                _buildMemberSection(
+                  title: '【担当者の一覧】',
+                  groups: data.shiftMembers,
+                  emptyMessage: '担当者はいません',
+                ),
+                const SizedBox(height: 12.0),
+                _buildMemberSection(
+                  title: '【前の時間の担当者の一覧】',
+                  groups: [data.beforeMembers],
+                  emptyMessage: '前の時間の担当者はいません',
+                ),
+                const SizedBox(height: 12.0),
+                _buildMemberSection(
+                  title: '【次の時間の担当者の一覧】',
+                  groups: [data.afterMembers],
+                  emptyMessage: '次の時間の担当者はいません',
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildMemberSection({
     required String title,
-    String? url,
+    required List<ShiftMembers> groups,
+    required String emptyMessage,
   }) {
-    return Padding(
-      padding: const EdgeInsets.only(top: 8.0, bottom: 8.0),
-      child: Align(
-        alignment: Alignment.centerLeft,
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              title,
-              style: const TextStyle(
-                fontSize: AppFontSizes.xs,
-                color: AppColors.textBlack,
-                fontWeight: FontWeight.bold,
-              ),
+    final validGroups =
+        groups.where((group) => group.members.isNotEmpty).toList();
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          title,
+          style: const TextStyle(
+            fontSize: AppFontSizes.xs,
+            color: AppColors.textBlack,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        const SizedBox(height: 4.0),
+        if (validGroups.isEmpty)
+          Text(
+            emptyMessage,
+            style: const TextStyle(
+              fontSize: AppFontSizes.xs,
+              color: AppColors.textBlack,
+              height: 1.5,
             ),
-            const SizedBox(height: 4.0),
-            if (url == null)
-              Text(
-                'マニュアルがありません',
+          )
+        else
+          ...validGroups.map(
+            (group) => Padding(
+              padding: const EdgeInsets.only(bottom: 4.0),
+              child: Text(
+                '${group.sTime}~${group.eTime}\n${group.members.map((member) => '(${member.bureau}${member.grade})${member.name}').join(', ')}',
                 style: const TextStyle(
                   fontSize: AppFontSizes.xs,
                   color: AppColors.textBlack,
-                  height: 1.5,
+                  height: 1.4,
                 ),
-              )
-            else
-              _InlineManualExpansion(url: url),
-          ],
-        ),
-      ),
+              ),
+            ),
+          ),
+      ],
     );
   }
 }
 
-// マニュアルをインラインで開閉するウィジェット
-class _InlineManualExpansion extends StatefulWidget {
-  final String url;
-  const _InlineManualExpansion({required this.url});
-
-  @override
-  State<_InlineManualExpansion> createState() => _InlineManualExpansionState();
+enum _ShiftCardMenuAction {
+  members,
+  review,
 }
 
-class _InlineManualExpansionState extends State<_InlineManualExpansion> {
-  bool _isExpanded = false;
+class _ShiftCardMoreButton extends StatelessWidget {
+  static const double _menuLeftOffset = 0.0;
+  static const double _menuTopOffset = 0.0;
+
+  final Future<void> Function(Offset position) onPressed;
+
+  const _ShiftCardMoreButton({required this.onPressed});
 
   @override
   Widget build(BuildContext context) {
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTapDown: (_) => onPressed(_menuPosition(context)),
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            color: Colors.transparent,
+            borderRadius: BorderRadius.circular(AppBorderRadius.normal),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Icon(
+              Icons.more_vert,
+              color: AppColors.textBlack,
+              size: 24,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Offset _menuPosition(BuildContext context) {
+    final box = context.findRenderObject() as RenderBox;
+    final topLeft = box.localToGlobal(Offset.zero);
+    return Offset(
+      topLeft.dx - _menuLeftOffset,
+      topLeft.dy + _menuTopOffset,
+    );
+  }
+}
+
+class _ShiftCardMenuPanel extends PopupMenuEntry<_ShiftCardMenuAction> {
+  const _ShiftCardMenuPanel();
+
+  @override
+  double get height => 138;
+
+  @override
+  bool represents(_ShiftCardMenuAction? value) => false;
+
+  @override
+  State<_ShiftCardMenuPanel> createState() => _ShiftCardMenuPanelState();
+}
+
+class _ShiftCardMenuPanelState extends State<_ShiftCardMenuPanel> {
+  _ShiftCardMenuAction? _hoveredAction;
+  _ShiftCardMenuAction? _pressedAction;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 1.0),
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(8.0),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withValues(alpha: 0.40),
+              offset: const Offset(0, 4),
+              blurRadius: 4.0,
+            ),
+          ],
+        ),
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(8.0),
+          child: ColoredBox(
+            color: AppColors.base,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const SizedBox(height: 8.0),
+                _ShiftCardMenuRow(
+                  action: _ShiftCardMenuAction.members,
+                  label: '担当者一覧',
+                  isHovered: _hoveredAction == _ShiftCardMenuAction.members,
+                  isPressed: _pressedAction == _ShiftCardMenuAction.members,
+                  onHoverChanged: _handleHoverChanged,
+                  onPressChanged: _handlePressChanged,
+                ),
+                _ShiftCardMenuRow(
+                  action: _ShiftCardMenuAction.review,
+                  label: 'レビューを書く',
+                  isHovered: _hoveredAction == _ShiftCardMenuAction.review,
+                  isPressed: _pressedAction == _ShiftCardMenuAction.review,
+                  onHoverChanged: _handleHoverChanged,
+                  onPressChanged: _handlePressChanged,
+                ),
+                const SizedBox(height: 8.0),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _handleHoverChanged(_ShiftCardMenuAction action, bool isHovered) {
+    setState(() {
+      _hoveredAction = isHovered ? action : null;
+    });
+  }
+
+  void _handlePressChanged(_ShiftCardMenuAction action, bool isPressed) {
+    setState(() {
+      _pressedAction = isPressed ? action : null;
+    });
+  }
+}
+
+class _ShiftCardMenuRow extends StatelessWidget {
+  final _ShiftCardMenuAction action;
+  final String label;
+  final bool isHovered;
+  final bool isPressed;
+  final void Function(_ShiftCardMenuAction action, bool isHovered)
+      onHoverChanged;
+  final void Function(_ShiftCardMenuAction action, bool isPressed)
+      onPressChanged;
+
+  const _ShiftCardMenuRow({
+    required this.action,
+    required this.label,
+    required this.isHovered,
+    required this.isPressed,
+    required this.onHoverChanged,
+    required this.onPressChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      onEnter: (_) => onHoverChanged(action, true),
+      onExit: (_) => onHoverChanged(action, false),
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTapDown: (_) => onPressChanged(action, true),
+        onTapCancel: () => onPressChanged(action, false),
+        onTapUp: (_) async {
+          await Future<void>.delayed(const Duration(milliseconds: 120));
+          if (context.mounted) {
+            Navigator.pop(context, action);
+          }
+        },
+        child: Container(
+          width: double.infinity,
+          height: 40,
+          alignment: Alignment.center,
+          color: _backgroundColor,
+          child: Text(
+            label,
+            style: TextStyle(
+              fontSize: AppFontSizes.sm,
+              color: isPressed ? AppColors.textWhite : AppColors.textBlack,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Color get _backgroundColor {
+    if (isPressed) return AppColors.main;
+    return AppColors.base;
+  }
+}
+
+class _ManualToggle extends StatefulWidget {
+  final String url;
+  final VoidCallback? onOpened;
+
+  const _ManualToggle({
+    required this.url,
+    this.onOpened,
+  });
+
+  @override
+  State<_ManualToggle> createState() => _ManualToggleState();
+}
+
+class _ManualToggleState extends State<_ManualToggle> {
+  bool _isExpanded = false;
+
+  bool get _hasManual => widget.url.isNotEmpty;
+
+  void _toggleManual() {
+    if (!_hasManual) return;
+    final willExpand = !_isExpanded;
+    setState(() => _isExpanded = willExpand);
+    if (willExpand && widget.onOpened != null) {
+      widget.onOpened!();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final textColor = _hasManual ? AppColors.link : AppColors.grayDark;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         InkWell(
           borderRadius: BorderRadius.circular(4.0),
-          onTap: () => setState(() => _isExpanded = !_isExpanded),
+          onTap: _hasManual ? _toggleManual : null,
           child: Padding(
             padding: const EdgeInsets.symmetric(vertical: 4.0),
             child: Row(
@@ -319,14 +484,14 @@ class _InlineManualExpansionState extends State<_InlineManualExpansion> {
                 Icon(
                   _isExpanded ? Icons.expand_less : Icons.expand_more,
                   size: 16,
-                  color: AppColors.link,
+                  color: textColor,
                 ),
                 const SizedBox(width: 4.0),
                 Text(
-                  _isExpanded ? 'マニュアルを閉じる' : 'マニュアルを見る',
-                  style: const TextStyle(
+                  _manualText,
+                  style: TextStyle(
                     fontSize: AppFontSizes.xs,
-                    color: AppColors.link,
+                    color: textColor,
                     height: 1.5,
                   ),
                 ),
@@ -336,9 +501,45 @@ class _InlineManualExpansionState extends State<_InlineManualExpansion> {
         ),
         if (_isExpanded) ...[
           const SizedBox(height: 8.0),
-          ManualViewer(url: widget.url),
+          DecoratedBox(
+            decoration: BoxDecoration(
+              border: Border.all(color: AppColors.link),
+              borderRadius: BorderRadius.circular(AppBorderRadius.normal),
+            ),
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(AppBorderRadius.normal),
+              child: Column(
+                children: [
+                  ManualViewer(url: widget.url),
+                  Align(
+                    alignment: Alignment.centerRight,
+                    child: TextButton(
+                      onPressed: () async {
+                        await launchUrl(
+                          Uri.parse(widget.url),
+                          mode: LaunchMode.externalApplication,
+                        );
+                      },
+                      child: const Text(
+                        '別のタブで開く',
+                        style: TextStyle(
+                          fontSize: AppFontSizes.xs,
+                          color: AppColors.link,
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
         ],
       ],
     );
+  }
+
+  String get _manualText {
+    if (!_hasManual) return 'マニュアルなし';
+    return _isExpanded ? 'マニュアルを閉じる' : 'マニュアルを開く';
   }
 }

--- a/mobile/lib/widgets/shift_card.dart
+++ b/mobile/lib/widgets/shift_card.dart
@@ -1,4 +1,5 @@
 import 'package:seeft_mobile/configs/importer.dart';
+import 'package:seeft_mobile/widgets/custom_error_snack_bar.dart';
 import 'package:seeft_mobile/widgets/manual_viewer.dart';
 import 'package:seeft_mobile/widgets/new_badge.dart';
 import 'package:seeft_mobile/widgets/review_bottom_sheet.dart';
@@ -513,10 +514,21 @@ class _ManualToggleState extends State<_ManualToggle> {
                     alignment: Alignment.centerRight,
                     child: TextButton(
                       onPressed: () async {
-                        await launchUrl(
-                          Uri.parse(widget.url),
-                          mode: LaunchMode.externalApplication,
-                        );
+                        var launched = false;
+                        try {
+                          launched = await launchUrl(
+                            Uri.parse(widget.url),
+                            mode: LaunchMode.externalApplication,
+                          );
+                        } catch (_) {
+                          launched = false;
+                        }
+                        if (!launched && context.mounted) {
+                          showCustomErrorSnackBar(
+                            context,
+                            'マニュアルを開けませんでした',
+                          );
+                        }
                       },
                       child: const Text(
                         '別のタブで開く',

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -49,6 +49,9 @@ dev_dependencies:
   flutter_launcher_icons: ^0.14.3
   flutter_lints: ^5.0.0
 
+  # url_launcherのテストでUrlLauncherPlatformをモックするため依存に明示 (depend_on_referenced_packages)
+  url_launcher_platform_interface: ^2.3.2
+
 flutter_icons:
   android: true
   ios: true

--- a/mobile/test/shift_card_key_identity_test.dart
+++ b/mobile/test/shift_card_key_identity_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:seeft_mobile/models/shift_card.dart';
+import 'package:seeft_mobile/widgets/shift_card.dart';
+
+ShiftCardData _fakeData(String taskName, String url) {
+  return ShiftCardData(
+    taskName: taskName,
+    startTime: '10:00',
+    endTime: '12:00',
+    place: '正門',
+    url: url,
+    shiftMembers: const [],
+    beforeMembers: ShiftMembers(sTime: '', eTime: '', members: const []),
+    afterMembers: ShiftMembers(sTime: '', eTime: '', members: const []),
+  );
+}
+
+Widget _wrap(List<ShiftCardData> orderedData) {
+  return MaterialApp(
+    home: Scaffold(
+      body: SingleChildScrollView(
+        child: Column(
+          children: orderedData
+              .map(
+                (data) => ShiftCard(
+                  key: ValueKey(data.taskName),
+                  data: data,
+                  userID: 1,
+                ),
+              )
+              .toList(),
+        ),
+      ),
+    ),
+  );
+}
+
+Finder _manualToggleTextWithinCard(String taskName, String text) {
+  return find.descendant(
+    of: find.widgetWithText(Card, taskName),
+    matching: find.text(text),
+  );
+}
+
+void main() {
+  testWidgets('Keyがあれば並び替え後もマニュアルの開閉状態が正しいカードに紐づく', (tester) async {
+    final cardA = _fakeData('A', 'https://example.com/a');
+    final cardB = _fakeData('B', 'https://example.com/b');
+
+    await tester.pumpWidget(_wrap([cardA, cardB]));
+    await tester.pumpAndSettle();
+
+    expect(_manualToggleTextWithinCard('A', 'マニュアルを開く'), findsOneWidget);
+    expect(_manualToggleTextWithinCard('B', 'マニュアルを開く'), findsOneWidget);
+
+    await tester.tap(_manualToggleTextWithinCard('A', 'マニュアルを開く'));
+    await tester.pumpAndSettle();
+
+    expect(_manualToggleTextWithinCard('A', 'マニュアルを閉じる'), findsOneWidget);
+    expect(_manualToggleTextWithinCard('B', 'マニュアルを開く'), findsOneWidget);
+
+    // 並び順を入れ替えて再描画（一覧の再取得・並び替えを想定）
+    await tester.pumpWidget(_wrap([cardB, cardA]));
+    await tester.pumpAndSettle();
+
+    // 開閉状態は位置ではなくKey（カードの中身）に紐づいたままであること
+    expect(_manualToggleTextWithinCard('A', 'マニュアルを閉じる'), findsOneWidget);
+    expect(_manualToggleTextWithinCard('B', 'マニュアルを開く'), findsOneWidget);
+  });
+}

--- a/mobile/test/shift_card_manual_launch_test.dart
+++ b/mobile/test/shift_card_manual_launch_test.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:seeft_mobile/models/shift_card.dart';
+import 'package:seeft_mobile/widgets/shift_card.dart';
+import 'package:url_launcher_platform_interface/link.dart';
+import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
+
+class _FakeUrlLauncherPlatform extends UrlLauncherPlatform {
+  _FakeUrlLauncherPlatform(this.launchResult);
+
+  final bool launchResult;
+
+  @override
+  LinkDelegate? get linkDelegate => null;
+
+  @override
+  Future<bool> canLaunch(String url) async => true;
+
+  @override
+  Future<bool> launchUrl(String url, LaunchOptions options) async {
+    return launchResult;
+  }
+}
+
+ShiftCardData _fakeDataWithManual() {
+  return ShiftCardData(
+    taskName: '受付',
+    startTime: '10:00',
+    endTime: '12:00',
+    place: '正門',
+    url: 'https://example.com/manual',
+    shiftMembers: const [],
+    beforeMembers: ShiftMembers(sTime: '', eTime: '', members: const []),
+    afterMembers: ShiftMembers(sTime: '', eTime: '', members: const []),
+  );
+}
+
+Widget _wrap() {
+  return MaterialApp(
+    home: Scaffold(
+      body: SingleChildScrollView(
+        child: ShiftCard(data: _fakeDataWithManual(), userID: 1),
+      ),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('外部起動に失敗した場合はエラーメッセージを表示する', (tester) async {
+    final originalPlatform = UrlLauncherPlatform.instance;
+    UrlLauncherPlatform.instance = _FakeUrlLauncherPlatform(false);
+    addTearDown(() => UrlLauncherPlatform.instance = originalPlatform);
+
+    await tester.pumpWidget(_wrap());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('マニュアルを開く'));
+    await tester.pumpAndSettle();
+
+    await tester.ensureVisible(find.text('別のタブで開く'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('別のタブで開く'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('マニュアルを開けませんでした'), findsOneWidget);
+  });
+
+  testWidgets('外部起動に成功した場合はエラーメッセージを表示しない', (tester) async {
+    final originalPlatform = UrlLauncherPlatform.instance;
+    UrlLauncherPlatform.instance = _FakeUrlLauncherPlatform(true);
+    addTearDown(() => UrlLauncherPlatform.instance = originalPlatform);
+
+    await tester.pumpWidget(_wrap());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('マニュアルを開く'));
+    await tester.pumpAndSettle();
+
+    await tester.ensureVisible(find.text('別のタブで開く'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('別のタブで開く'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('マニュアルを開けませんでした'), findsNothing);
+  });
+}

--- a/mobile/test/shift_card_menu_accessibility_test.dart
+++ b/mobile/test/shift_card_menu_accessibility_test.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:seeft_mobile/models/shift_card.dart';
+import 'package:seeft_mobile/widgets/shift_card.dart';
+
+ShiftCardData _fakeData() {
+  return ShiftCardData(
+    taskName: '受付',
+    startTime: '10:00',
+    endTime: '12:00',
+    place: '正門',
+    url: '',
+    shiftMembers: [
+      ShiftMembers(sTime: '10:00', eTime: '12:00', members: []),
+    ],
+    beforeMembers: ShiftMembers(sTime: '', eTime: '', members: []),
+    afterMembers: ShiftMembers(sTime: '', eTime: '', members: []),
+  );
+}
+
+Widget _wrap() {
+  return MaterialApp(
+    home: Scaffold(
+      body: Center(
+        child: SizedBox(
+          width: 320,
+          child: ShiftCard(data: _fakeData(), userID: 1),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('三点メニューが開き、担当者一覧ダイアログを表示する（タップ操作）', (tester) async {
+    await tester.pumpWidget(_wrap());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byIcon(Icons.more_vert));
+    await tester.pumpAndSettle();
+
+    expect(find.text('担当者一覧'), findsOneWidget);
+    expect(find.text('レビューを書く'), findsOneWidget);
+
+    await tester.tap(find.text('担当者一覧'));
+    await tester.pump(const Duration(milliseconds: 200));
+    await tester.pumpAndSettle();
+
+    expect(find.text('【担当者の一覧】'), findsOneWidget);
+  });
+
+  testWidgets('三点ボタンとメニュー項目にボタンとしてのSemanticsが付いている', (tester) async {
+    final handle = tester.ensureSemantics();
+    await tester.pumpWidget(_wrap());
+    await tester.pumpAndSettle();
+
+    final moreButtonSemantics =
+        tester.getSemantics(find.byIcon(Icons.more_vert));
+    expect(moreButtonSemantics.hasFlag(SemanticsFlag.isButton), isTrue);
+
+    await tester.tap(find.byIcon(Icons.more_vert));
+    await tester.pumpAndSettle();
+
+    final membersRowSemantics = tester.getSemantics(find.text('担当者一覧'));
+    expect(membersRowSemantics.hasFlag(SemanticsFlag.isButton), isTrue);
+    expect(membersRowSemantics.label, contains('担当者一覧'));
+
+    handle.dispose();
+  });
+
+  testWidgets('三点ボタンにTabでフォーカスが当たりEnterでメニューが開く（キーボード操作）',
+      (tester) async {
+    await tester.pumpWidget(_wrap());
+    await tester.pumpAndSettle();
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+    await tester.pumpAndSettle();
+
+    expect(FocusManager.instance.primaryFocus, isNotNull);
+    expect(find.text('担当者一覧'), findsNothing);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.pumpAndSettle();
+
+    expect(find.text('担当者一覧'), findsOneWidget);
+    expect(find.text('レビューを書く'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
# 対応Issue 410

resolve #410 
feat/danimaru/410/design-change

# 概要
- シフトカードのデザインを変更
- 三点リーダーから担当者一覧・レビュー投稿を開けるように変更
- マニュアルをカード内で開閉できる表示に変更
- マニュアルの表示はあんまり手つけてないです

# 画面スクリーンショット等
<img width="281" height="121" alt="image" src="https://github.com/user-attachments/assets/b2f70cd8-2325-43dc-8636-60c017b2aaa2" />
<img width="283" height="128" alt="image" src="https://github.com/user-attachments/assets/6900044b-1cf6-4fc3-b08f-ca3e15fc1cc4" />
<img width="299" height="352" alt="image" src="https://github.com/user-attachments/assets/228ef20a-f47d-455a-8d07-54e9b8e95bc8" />
<img width="170" height="260" alt="image" src="https://github.com/user-attachments/assets/5d72dcd9-54e6-4c7e-8362-727e3cf90441" />
<img width="170" height="193" alt="image" src="https://github.com/user-attachments/assets/94ab444d-7e12-4a08-88a8-948906433214" />


# テスト項目
- デザインの確認

# 備考

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary（更新）

* **新機能**
  * シフトカード内でマニュアルを展開・折りたたみできるようになりました。
  * マニュアルを外部アプリ／別タブで開けるようになりました。
  * メニューから「担当者一覧」「レビューを書く」を選択できるようになりました。
* **改善**
  * 「別タブで開く」失敗時にエラースナックバーを表示します。
  * カードの並び替え後も、マニュアルの開閉状態がカードごとに維持されます。
* **テスト**
  * マニュアル操作・メニュー表示・アクセシビリティ等の検証を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->