### PR TITLE
fix: UTCtoJST

### DIFF
--- a/api/lib/usecase/review_usecase.go
+++ b/api/lib/usecase/review_usecase.go
@@ -36,6 +36,8 @@ func (u *reviewUseCase) GetReviewsGAS(ctx context.Context) ([]entity.ReviewGAS, 
 	}
 	defer func() { _ = rows.Close() }()
 
+	loc, locErr := time.LoadLocation("Asia/Tokyo")
+
 	var res []entity.ReviewGAS
 	for rows.Next() {
 		var r entity.ReviewGAS
@@ -55,9 +57,14 @@ func (u *reviewUseCase) GetReviewsGAS(ctx context.Context) ([]entity.ReviewGAS, 
 		); err != nil {
 			return nil, errors.Wrap(err, "rows.Scan")
 		}
+		if locErr == nil {
+        r.CreatedAt = created.In(loc).Format("2006/01/02 15:04:05")
+        r.UpdatedAt = updated.In(loc).Format("2006/01/02 15:04:05")
+    	} else {
 		r.CreatedAt = created.Format("2006/01/02 15:04:05")
 		r.UpdatedAt = updated.Format("2006/01/02 15:04:05")
-		res = append(res, r)
+		}
+		res = append(res, r)		
 	}
 	return res, nil
 }
@@ -68,6 +75,8 @@ func (u *reviewUseCase) GetReviewGASByID(ctx context.Context, id string) (entity
 	if err != nil {
 		return entity.ReviewGAS{}, errors.Wrap(err, "reviewRep.FindWithDetails")
 	}
+
+	loc, locErr := time.LoadLocation("Asia/Tokyo")
 
 	var r entity.ReviewGAS
 	var created, updated time.Time
@@ -86,8 +95,13 @@ func (u *reviewUseCase) GetReviewGASByID(ctx context.Context, id string) (entity
 	); err != nil {
 		return entity.ReviewGAS{}, err
 	}
-	r.CreatedAt = created.Format("2006/01/02 15:04:05")
-	r.UpdatedAt = updated.Format("2006/01/02 15:04:05")
+	if locErr == nil {
+    r.CreatedAt = created.In(loc).Format("2006/01/02 15:04:05")
+    r.UpdatedAt = updated.In(loc).Format("2006/01/02 15:04:05")
+	} else {
+    r.CreatedAt = created.Format("2006/01/02 15:04:05")
+    r.UpdatedAt = updated.Format("2006/01/02 15:04:05")
+	}
 	return r, nil
 }
 


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #320

# 概要
<!-- 開発内容の概要を記載 -->
DS部門からの要望に基づき，スプレッドシート（GAS）向けに返却しているシフトレビューの日時（作成日時・更新日時）がUTC表示（JSTより9時間遅い）になっていた問題を，日本時間（JST: Asia/Tokyo）に変換して出力するように修正した変更です．

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
スクリーンショット

# テスト項目
<!-- テストしてほしい内容を記載 -->
-
-
-

# 備考

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * レビューの作成日時・更新日時を、日本時間（Asia/Tokyo）で表示するようになりました。
  * 表示形式を「YYYY/MM/DD HH:MM:SS」に統一しました。
  * 日本時間の取得に失敗した場合も、従来の日時表示で継続して確認できます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->