### PR TITLE
fix: shift-cardsのGetUsersByShift呼び出し回数を削減しN+1を解消

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -3,11 +3,13 @@ module github.com/NUTFes/SeeFT/api
 go 1.26.0
 
 require (
+	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/joho/godotenv v1.5.1
 	github.com/labstack/echo/v4 v4.9.0
 	github.com/lib/pq v1.10.9
 	github.com/pkg/errors v0.9.1
 	github.com/slack-go/slack v0.12.3
+	github.com/stretchr/testify v1.11.1
 	github.com/swaggo/echo-swagger v1.3.5
 	github.com/swaggo/swag v1.8.1
 	golang.org/x/crypto v0.8.0
@@ -19,6 +21,7 @@ require (
 	github.com/KyleBanks/depth v1.2.1 // indirect
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.19.6 // indirect
 	github.com/go-openapi/spec v0.20.4 // indirect
@@ -35,6 +38,7 @@ require (
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.11 // indirect
 	github.com/mattn/go-isatty v0.0.17 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.8.0 // indirect
 	github.com/swaggo/files v0.0.0-20220728132757-551d4a08d97a // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
@@ -45,4 +49,5 @@ require (
 	golang.org/x/time v0.0.0-20201208040808-7e3f01d25324 // indirect
 	golang.org/x/tools v0.6.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/api/go.sum
+++ b/api/go.sum
@@ -1,4 +1,6 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
+github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc=
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
 github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tNFfI=
@@ -47,6 +49,7 @@ github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwA
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
+github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
 github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
@@ -95,8 +98,8 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
-github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/swaggo/echo-swagger v1.3.5 h1:kCx1wvX5AKhjI6Ykt48l3PTsfL9UD40ZROOx/tYzWyY=
 github.com/swaggo/echo-swagger v1.3.5/go.mod h1:3IMHd2Z8KftdWFEEjGmv6QpWj370LwMCOfovuh7vF34=
 github.com/swaggo/files v0.0.0-20220728132757-551d4a08d97a h1:kAe4YSu0O0UFn1DowNo2MY5p6xzqtJ/wQ7LZynSvGaY=

--- a/api/lib/internals/repository/shift_repository.go
+++ b/api/lib/internals/repository/shift_repository.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/NUTFes/SeeFT/api/lib/externals/db"
 	"github.com/NUTFes/SeeFT/api/lib/internals/repository/abstract"
+	"github.com/lib/pq"
 	"github.com/pkg/errors"
 )
 
@@ -20,6 +21,7 @@ type ShiftRepository interface {
 	Find(context.Context, string) (*sql.Row, error)
 	User(context.Context, string) (*sql.Rows, error)
 	Users(context.Context, string, string, string, string, string) (*sql.Rows, error)
+	UsersByTimes(context.Context, string, string, string, []int, string) (*sql.Rows, error)
 	UserAndDateAndWeather(context.Context, string, string, string) (*sql.Rows, error)
 	DateAndWeather(context.Context, string, string) (*sql.Rows, error)
 	DateAndWeatherAndTime(context.Context, string, string, string, string) (*sql.Rows, error)
@@ -68,6 +70,18 @@ func (b *shiftRepository) Users(c context.Context, task string, year string, dat
 	}
 	fmt.Printf("\x1b[36m%s\n", query)
 	return rows, nil
+}
+
+// 複数の時間帯のユーザーをまとめて取得（shift-cardsのN+1解消。ShiftCard生成時にtime_idごとに
+// Usersを繰り返し呼んでいたのを1クエリにまとめるための専用メソッド。GetUsersByShiftはShowUsersByShift
+// エンドポイントが単一time_id版として引き続き使うため変更しない）
+func (b *shiftRepository) UsersByTimes(c context.Context, task string, year string, date string, times []int, weather string) (*sql.Rows, error) {
+	if len(times) == 0 {
+		query := "SELECT s.time_id, u.id, u.name, u.mail, u.grade_id, u.department_id, u.bureau_id, u.role_id, u.student_number, u.tel, u.created_at, u.updated_at, COALESCE(u.slack_user_id, '') FROM shifts s JOIN users u ON s.user_id = u.id WHERE 1=0"
+		return b.crud.Read(c, query)
+	}
+	query := "SELECT s.time_id, u.id, u.name, u.mail, u.grade_id, u.department_id, u.bureau_id, u.role_id, u.student_number, u.tel, u.created_at, u.updated_at, COALESCE(u.slack_user_id, '') FROM shifts s JOIN users u ON s.user_id = u.id WHERE s.task_id = $1 AND s.year_id = $2 AND s.date_id = $3 AND s.time_id = ANY($4) AND s.weather_id = $5"
+	return b.crud.Read(c, query, task, year, date, pq.Array(times), weather)
 }
 
 // 特定のユーザと日時取得

--- a/api/lib/usecase/shift_usecase.go
+++ b/api/lib/usecase/shift_usecase.go
@@ -165,6 +165,63 @@ func (a *shiftUseCase) GetUsersByShift(c context.Context, task string, year stri
 	return shiftUsers, nil
 }
 
+// getUsersByTimes は同一task/year/date/weatherで複数time_idにまたがるシフトメンバーを
+// 1クエリでまとめて取得し、time_idごとに振り分ける（shift-cardsのN+1解消）。
+// year/date/time/weatherの個別Findは呼び出し元(getShiftMembersForTime等)で
+// 使われていなかったため、意図的に取得しない。
+func (a *shiftUseCase) getUsersByTimes(c context.Context, taskID, yearID, dateID, weatherID int, timeIDs []int) (map[int][]entity.User, error) {
+	usersByTime := make(map[int][]entity.User, len(timeIDs))
+	if len(timeIDs) == 0 {
+		return usersByTime, nil
+	}
+
+	rows, err := a.rep.UsersByTimes(c,
+		strconv.Itoa(taskID), strconv.Itoa(yearID), strconv.Itoa(dateID), timeIDs, strconv.Itoa(weatherID))
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		var timeID int
+		var user entity.User
+		err := rows.Scan(
+			&timeID,
+			&user.ID,
+			&user.Name,
+			&user.Mail,
+			&user.GradeID,
+			&user.DepartmentID,
+			&user.BureauID,
+			&user.RoleID,
+			&user.StudentNumber,
+			&user.Tel,
+			&user.CreatedAt,
+			&user.UpdatedAt,
+			&user.SlackUserID,
+		)
+		if err != nil {
+			return nil, errors.Wrapf(err, "cannot connect SQL")
+		}
+		usersByTime[timeID] = append(usersByTime[timeID], user)
+	}
+
+	return usersByTime, nil
+}
+
+// toShiftMembers はUser群をShiftMemberに変換する（grade/bureauはマップから引く）
+func (a *shiftUseCase) toShiftMembers(users []entity.User, gradeMap, bureauMap map[int]string) []entity.ShiftMember {
+	members := make([]entity.ShiftMember, 0, len(users))
+	for _, user := range users {
+		members = append(members, entity.ShiftMember{
+			Name:   user.Name,
+			Grade:  gradeMap[user.GradeID],
+			Bureau: bureauMap[user.BureauID],
+		})
+	}
+	return members
+}
+
 // Webアプリ用API
 
 func (a *shiftUseCase) GetShiftAdminByID(c context.Context, id string) (entity.ShiftAdmin, error) {
@@ -571,15 +628,51 @@ func (a *shiftUseCase) createShiftCardFromGroup(c context.Context, group []entit
 		ShiftMembers: []entity.ShiftMembers{}, // 空配列で初期化
 	}
 
+	// 必要なtime_id（各スロット＋前後1枠）を先に集め、メンバー取得を1回のバッチクエリにまとめる
+	// （shift-cardsのN+1解消。前後スロットの存在確認は既存のgetPreviousTimeString/
+	// getNextTimeStringのロジックをそのまま使う）
+	timeIDs := make([]int, 0, len(group)+2)
+	for _, shift := range group {
+		timeIDs = append(timeIDs, shift.Time.ID)
+	}
+
+	prevTimeID := first.Time.ID - 1
+	var prevTimeString string
+	hasPrev := false
+	if prevTimeID >= 1 {
+		if s, err := a.getPreviousTimeString(c, first.Time.ID); err == nil {
+			prevTimeString, hasPrev = s, true
+			timeIDs = append(timeIDs, prevTimeID)
+		}
+	}
+
+	nextTimeID := last.Time.ID + 1
+	var nextStart, nextEnd string
+	hasNext := false
+	if s, err := a.getNextTimeString(c, last.Time.ID); err == nil && s != "" {
+		nextStart = s
+		if e, err := a.getNextTimeString(c, nextTimeID); err == nil {
+			nextEnd = e
+		} else {
+			nextEnd = nextStart
+		}
+		hasNext = true
+		timeIDs = append(timeIDs, nextTimeID)
+	}
+
+	usersByTime, err := a.getUsersByTimes(c, first.Task.ID, first.Year.ID, first.Date.ID, first.Weather.ID, timeIDs)
+	if err != nil {
+		// エラー時は全て空扱い（既存のgetShiftMembersForTime/getBeforeMembers/getAfterMembersの
+		// エラー時フォールバックを踏襲）
+		usersByTime = map[int][]entity.User{}
+		hasPrev = false
+		hasNext = false
+	}
+
 	// ShiftMembersを生成（15分ごと）
 	var shiftMembers []entity.ShiftMembers
 	for i, shift := range group {
-		members := a.getShiftMembersForTime(c, shift, gradeMap, bureauMap)
-
-		// メンバーがnilの場合は空配列を設定
-		if members == nil {
-			members = []entity.ShiftMember{}
-		}
+		members := a.toShiftMembers(usersByTime[shift.Time.ID], gradeMap, bureauMap)
 
 		// 終了時刻を計算
 		var eTime string
@@ -604,176 +697,25 @@ func (a *shiftUseCase) createShiftCardFromGroup(c context.Context, group []entit
 	}
 	shiftCard.ShiftMembers = shiftMembers
 
-	// BeforeMembersを取得（nilチェック付き）
-	beforeMembers := a.getBeforeMembers(c, first, gradeMap, bureauMap)
-	if beforeMembers.Members == nil {
-		beforeMembers.Members = []entity.ShiftMember{}
+	// BeforeMembersを設定
+	beforeMembers := entity.ShiftMembers{Members: []entity.ShiftMember{}}
+	if hasPrev {
+		beforeMembers.STime = prevTimeString
+		beforeMembers.ETime = first.Time.Time
+		beforeMembers.Members = a.toShiftMembers(usersByTime[prevTimeID], gradeMap, bureauMap)
 	}
 	shiftCard.BeforeMembers = beforeMembers
 
-	// AfterMembersを取得（nilチェック付き）
-	afterMembers := a.getAfterMembers(c, last, gradeMap, bureauMap)
-	if afterMembers.Members == nil {
-		afterMembers.Members = []entity.ShiftMember{}
+	// AfterMembersを設定
+	afterMembers := entity.ShiftMembers{Members: []entity.ShiftMember{}}
+	if hasNext {
+		afterMembers.STime = nextStart
+		afterMembers.ETime = nextEnd
+		afterMembers.Members = a.toShiftMembers(usersByTime[nextTimeID], gradeMap, bureauMap)
 	}
 	shiftCard.AfterMembers = afterMembers
 
 	return shiftCard
-}
-
-// getShiftMembersForTime は指定時間のメンバーを取得
-func (a *shiftUseCase) getShiftMembersForTime(c context.Context, shift entity.Shift, gradeMap map[int]string, bureauMap map[int]string) []entity.ShiftMember {
-	shiftUsers, err := a.GetUsersByShift(c,
-		strconv.Itoa(shift.Task.ID),
-		strconv.Itoa(shift.Year.ID),
-		strconv.Itoa(shift.Date.ID),
-		strconv.Itoa(shift.Time.ID),
-		strconv.Itoa(shift.Weather.ID))
-
-	if err != nil {
-		return []entity.ShiftMember{} // エラー時は空配列を返す
-	}
-
-	var members []entity.ShiftMember
-	for _, user := range shiftUsers.Users {
-		// マップからGrade/Bureau情報を取得（N+1問題を回避）
-		grade := gradeMap[user.GradeID]
-		bureau := bureauMap[user.BureauID]
-
-		member := entity.ShiftMember{
-			Name:   user.Name,
-			Grade:  grade,
-			Bureau: bureau,
-		}
-		members = append(members, member)
-	}
-
-	if members == nil {
-		return []entity.ShiftMember{}
-	}
-
-	return members
-}
-
-// getBeforeMembers は前の時間のメンバーを取得
-func (a *shiftUseCase) getBeforeMembers(c context.Context, firstShift entity.Shift, gradeMap map[int]string, bureauMap map[int]string) entity.ShiftMembers {
-	// 初期化（空配列を保証）
-	result := entity.ShiftMembers{
-		STime:   "",
-		ETime:   "",
-		Members: []entity.ShiftMember{},
-	}
-
-	// 前の時間のID
-	prevTimeID := firstShift.Time.ID - 1
-	if prevTimeID < 1 {
-		return result
-	}
-
-	// 前の時間の文字列を取得
-	prevTimeString, err := a.getPreviousTimeString(c, firstShift.Time.ID)
-	if err != nil {
-		return result
-	}
-
-	// 前の時間のメンバーを取得
-	prevUsers, err := a.GetUsersByShift(c,
-		strconv.Itoa(firstShift.Task.ID),
-		strconv.Itoa(firstShift.Year.ID),
-		strconv.Itoa(firstShift.Date.ID),
-		strconv.Itoa(prevTimeID),
-		strconv.Itoa(firstShift.Weather.ID))
-
-	if err != nil {
-		return result
-	}
-
-	var members []entity.ShiftMember
-	for _, user := range prevUsers.Users {
-		// マップからGrade/Bureau情報を取得（N+1問題を回避）
-		grade := gradeMap[user.GradeID]
-		bureau := bureauMap[user.BureauID]
-
-		member := entity.ShiftMember{
-			Name:   user.Name,
-			Grade:  grade,
-			Bureau: bureau,
-		}
-		members = append(members, member)
-	}
-
-	if members == nil {
-		members = []entity.ShiftMember{}
-	}
-
-	result.STime = prevTimeString
-	result.ETime = firstShift.Time.Time
-	result.Members = members
-
-	return result
-}
-
-// getAfterMembers は後の時間のメンバーを取得（同様の実装）
-func (a *shiftUseCase) getAfterMembers(c context.Context, lastShift entity.Shift, gradeMap map[int]string, bureauMap map[int]string) entity.ShiftMembers {
-	// 次の時間帯情報（空配列は保証）
-	result := entity.ShiftMembers{
-		STime:   "",
-		ETime:   "",
-		Members: []entity.ShiftMember{},
-	}
-
-	// 次の時間ID
-	nextTimeID := lastShift.Time.ID + 1
-	if nextTimeID < 1 {
-		return result
-	}
-
-	// 次の時間帯の開始時刻（lastShift の直後）
-	nextStart, err := a.getNextTimeString(c, lastShift.Time.ID)
-	if err != nil || nextStart == "" {
-		return result
-	}
-
-	// 次の次の時間帯の開始時刻（終了時刻として使用）
-	nextEnd, err := a.getNextTimeString(c, nextTimeID)
-	if err != nil {
-		// フォールバック（環境によっては末尾時刻で終端）
-		nextEnd = nextStart
-	}
-
-	// 次の時間帯に属するメンバーを取得
-	nextUsers, err := a.GetUsersByShift(c,
-		strconv.Itoa(lastShift.Task.ID),
-		strconv.Itoa(lastShift.Year.ID),
-		strconv.Itoa(lastShift.Date.ID),
-		strconv.Itoa(nextTimeID),
-		strconv.Itoa(lastShift.Weather.ID))
-	if err != nil {
-		return result
-	}
-
-	var members []entity.ShiftMember
-	for _, user := range nextUsers.Users {
-		// マップからGrade/Bureau情報を取得（N+1問題を回避）
-		grade := gradeMap[user.GradeID]
-		bureau := bureauMap[user.BureauID]
-
-		member := entity.ShiftMember{
-			Name:   user.Name,
-			Grade:  grade,
-			Bureau: bureau,
-		}
-		members = append(members, member)
-	}
-	if members == nil {
-		members = []entity.ShiftMember{}
-	}
-
-	result.STime = nextStart
-	result.ETime = nextEnd
-	result.Members = members
-
-	return result
 }
 
 // -----------------

--- a/api/lib/usecase/shift_usecase.go
+++ b/api/lib/usecase/shift_usecase.go
@@ -165,8 +165,8 @@ func (a *shiftUseCase) GetUsersByShift(c context.Context, task string, year stri
 	return shiftUsers, nil
 }
 
-// getUsersByTimes は同一task/year/date/weatherで複数time_idにまたがるシフトメンバーを
-// 1クエリでまとめて取得し、time_idごとに振り分ける（shift-cardsのN+1解消）。
+// 同一task/year/date/weatherで複数time_idにまたがるシフトメンバーを1クエリでまとめて取得し、
+// time_idごとに振り分ける（shift-cardsのN+1解消）。
 // year/date/time/weatherの個別Findは呼び出し元(getShiftMembersForTime等)で
 // 使われていなかったため、意図的に取得しない。
 func (a *shiftUseCase) getUsersByTimes(c context.Context, taskID, yearID, dateID, weatherID int, timeIDs []int) (map[int][]entity.User, error) {
@@ -209,7 +209,7 @@ func (a *shiftUseCase) getUsersByTimes(c context.Context, taskID, yearID, dateID
 	return usersByTime, nil
 }
 
-// toShiftMembers はUser群をShiftMemberに変換する（grade/bureauはマップから引く）
+// User群をShiftMemberに変換する（grade/bureauはマップから引く）
 func (a *shiftUseCase) toShiftMembers(users []entity.User, gradeMap, bureauMap map[int]string) []entity.ShiftMember {
 	members := make([]entity.ShiftMember, 0, len(users))
 	for _, user := range users {
@@ -612,9 +612,10 @@ func (a *shiftUseCase) createShiftCardFromGroup(c context.Context, group []entit
 	first := group[0]
 	last := group[len(group)-1]
 
-	// 終了時刻を取得
-	endTime, err := a.getNextTimeString(c, last.Time.ID)
-	if err != nil {
+	// 終了時刻を取得（同じ問い合わせをEndTime算出・前後判定・最終スロットのeTime再計算で共有する）
+	nextOfLast, nextOfLastErr := a.getNextTimeString(c, last.Time.ID)
+	endTime := nextOfLast
+	if nextOfLastErr != nil {
 		endTime = last.Time.Time // フォールバック
 	}
 
@@ -649,8 +650,8 @@ func (a *shiftUseCase) createShiftCardFromGroup(c context.Context, group []entit
 	nextTimeID := last.Time.ID + 1
 	var nextStart, nextEnd string
 	hasNext := false
-	if s, err := a.getNextTimeString(c, last.Time.ID); err == nil && s != "" {
-		nextStart = s
+	if nextOfLastErr == nil && nextOfLast != "" {
+		nextStart = nextOfLast
 		if e, err := a.getNextTimeString(c, nextTimeID); err == nil {
 			nextEnd = e
 		} else {
@@ -674,17 +675,14 @@ func (a *shiftUseCase) createShiftCardFromGroup(c context.Context, group []entit
 	for i, shift := range group {
 		members := a.toShiftMembers(usersByTime[shift.Time.ID], gradeMap, bureauMap)
 
-		// 終了時刻を計算
+		// 終了時刻を計算（最終スロットはEndTime算出時に取得済みのnextOfLastを再利用する）
 		var eTime string
 		if i < len(group)-1 {
 			eTime = group[i+1].Time.Time
+		} else if nextOfLastErr != nil {
+			eTime = shift.Time.Time
 		} else {
-			nextTime, err := a.getNextTimeString(c, shift.Time.ID)
-			if err != nil {
-				eTime = shift.Time.Time
-			} else {
-				eTime = nextTime
-			}
+			eTime = nextOfLast
 		}
 
 		shiftMember := entity.ShiftMembers{

--- a/api/lib/usecase/shift_usecase_shiftcards_sqlmock_test.go
+++ b/api/lib/usecase/shift_usecase_shiftcards_sqlmock_test.go
@@ -167,9 +167,9 @@ func TestGetShiftCardsByUserAndDateAndWeather_SingleCardBatchesUserFetch(t *test
 			AddRow(userRow(1, 1, "Alice")...).
 			AddRow(userRow(3, 2, "Bob")...))
 
-	// 前後スロット(time_id=0, 7)は存在しない前提。endTime計算・前後判定・最終スロットのeTime再計算の
-	// 3回、いずれもtime_id=7のFindが呼ばれるが該当なしを返す
-	expectNoMoreTimes(mock, 3)
+	// 前後スロット(time_id=0, 7)は存在しない前提。time_id=7のFindはEndTime算出・前後判定・
+	// 最終スロットのeTime再計算で共有されるため1回だけ呼ばれ、該当なしを返す
+	expectNoMoreTimes(mock, 1)
 
 	cards, err := uc.GetShiftCardsByUserAndDateAndWeather(context.Background(), "10", "2", "1")
 	require.NoError(t, err)
@@ -225,8 +225,8 @@ func TestGetShiftCardsByUserAndDateAndWeather_TwoTasksBatchPerCard(t *testing.T)
 		WillReturnRows(sqlmock.NewRows(emptyUsersCols).AddRow(userRow(1, 2, "Bob")...))
 
 	// 両カードとも time_id=1..2 で連続し、前スロット(0)は存在せず、後ろのFind(3)も該当なし。
-	// カードごとに3回(endTime/前後判定/最終スロットeTime再計算)、2カード分で合計6回
-	expectNoMoreTimes(mock, 6)
+	// カードごとに1回(endTime/前後判定/最終スロットeTime再計算で共有)、2カード分で合計2回
+	expectNoMoreTimes(mock, 2)
 
 	cards, err := uc.GetShiftCardsByUserAndDateAndWeather(context.Background(), "10", "2", "1")
 	require.NoError(t, err)

--- a/api/lib/usecase/shift_usecase_shiftcards_sqlmock_test.go
+++ b/api/lib/usecase/shift_usecase_shiftcards_sqlmock_test.go
@@ -1,0 +1,257 @@
+package usecase
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/NUTFes/SeeFT/api/lib/entity"
+	"github.com/NUTFes/SeeFT/api/lib/internals/repository"
+	"github.com/NUTFes/SeeFT/api/lib/internals/repository/abstract"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+// fakeDBClient は db.Client を満たす最小限のフェイク。shiftCardRepository は
+// GormDB() 経由、他のrepositoryはDB() 経由でクエリを発行するため、両方が
+// 同一の sqlmock インスタンスを共有するようにする。
+type fakeDBClient struct {
+	sqlDB  *sql.DB
+	gormDB *gorm.DB
+}
+
+func (f *fakeDBClient) DB() *sql.DB      { return f.sqlDB }
+func (f *fakeDBClient) GormDB() *gorm.DB { return f.gormDB }
+func (f *fakeDBClient) CloseDB()         { _ = f.sqlDB.Close() }
+
+func newFakeDBClient(t *testing.T) (*fakeDBClient, sqlmock.Sqlmock) {
+	t.Helper()
+
+	sqlDB, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+	require.NoError(t, err)
+
+	gormDB, err := gorm.Open(postgres.New(postgres.Config{
+		Conn:                 sqlDB,
+		PreferSimpleProtocol: true,
+	}), &gorm.Config{})
+	require.NoError(t, err)
+
+	return &fakeDBClient{sqlDB: sqlDB, gormDB: gormDB}, mock
+}
+
+var fixedTestTime = time.Date(2026, 7, 24, 9, 0, 0, 0, time.UTC)
+
+func userRow(timeID, id int, name string) []driver.Value {
+	return []driver.Value{timeID, id, name, name + "@example.com", 1, 1, 1, 1, 90000000 + id, "000", fixedTestTime, fixedTestTime, ""}
+}
+
+func TestGetUsersByTimes_SingleBatchedQuery(t *testing.T) {
+	client, mock := newFakeDBClient(t)
+	defer client.CloseDB()
+
+	crud := abstract.NewCrud(client)
+	shiftRep := repository.NewShiftRepository(client, crud)
+	uc := &shiftUseCase{rep: shiftRep}
+
+	cols := []string{"time_id", "id", "name", "mail", "grade_id", "department_id", "bureau_id", "role_id", "student_number", "tel", "created_at", "updated_at", "slack_user_id"}
+	rows := sqlmock.NewRows(cols).
+		AddRow(userRow(41, 1, "Alice")...).
+		AddRow(userRow(42, 2, "Bob")...).
+		AddRow(42, 3, "Carol", "carol@example.com", 2, 1, 2, 1, 90000003, "000", fixedTestTime, fixedTestTime, "")
+
+	mock.ExpectQuery(`s\.time_id = ANY\(\$4\)`).
+		WithArgs("4", "43", "2", sqlmock.AnyArg(), "1").
+		WillReturnRows(rows)
+
+	result, err := uc.getUsersByTimes(context.Background(), 4, 43, 2, 1, []int{41, 42})
+	require.NoError(t, err)
+
+	require.Len(t, result[41], 1)
+	assert.Equal(t, "Alice", result[41][0].Name)
+
+	require.Len(t, result[42], 2)
+	assert.Equal(t, "Bob", result[42][0].Name)
+	assert.Equal(t, "Carol", result[42][1].Name)
+
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestGetUsersByTimes_EmptyTimeIDsSkipsQuery(t *testing.T) {
+	client, mock := newFakeDBClient(t)
+	defer client.CloseDB()
+
+	crud := abstract.NewCrud(client)
+	shiftRep := repository.NewShiftRepository(client, crud)
+	uc := &shiftUseCase{rep: shiftRep}
+
+	result, err := uc.getUsersByTimes(context.Background(), 4, 43, 2, 1, nil)
+	require.NoError(t, err)
+	assert.Empty(t, result)
+
+	// time_id が空の場合はリポジトリへ問い合わせすら発生しないこと
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+var shiftCardCols = []string{
+	"shift_id", "user_id", "task_id", "year_id", "date_id", "time_id", "weather_id", "is_attendance",
+	"task_name", "task_color", "task_url", "task_remark", "max_member", "task_bureau_id",
+	"place_id", "place_name", "time_value",
+	"user_name", "user_bureau_id", "user_grade_id",
+	"year_value", "date_value", "weather_value",
+}
+
+func shiftCardDataRow(shiftID, userID, taskID, yearID, dateID, timeID, weatherID int, taskName, timeValue string) []driver.Value {
+	return []driver.Value{
+		shiftID, userID, taskID, yearID, dateID, timeID, weatherID, true,
+		taskName, "#ffffff", "", "", 5, 1,
+		1, "1号館", timeValue,
+		"シフト太郎", 1, 1,
+		"2026", "9/6", "晴れ",
+	}
+}
+
+// expectNoMoreTimes は timeRep.Find(times WHERE id = ...) への問い合わせを「該当なし」として
+// n回分まとめて登録する。境界スロット（前後の枠が存在しない）を模擬するための共通ヘルパー。
+func expectNoMoreTimes(mock sqlmock.Sqlmock, n int) {
+	emptyCols := []string{"id", "time", "created_at", "updated_at"}
+	for range n {
+		mock.ExpectQuery(`(?i)FROM times WHERE id =`).WillReturnRows(sqlmock.NewRows(emptyCols))
+	}
+}
+
+func newFullShiftUseCase(client *fakeDBClient) *shiftUseCase {
+	crud := abstract.NewCrud(client)
+	return &shiftUseCase{
+		rep:          repository.NewShiftRepository(client, crud),
+		shiftCardRep: repository.NewShiftCardRepository(client),
+		timeRep:      repository.NewTimeRepository(client, crud),
+		gradeRep:     repository.NewGradeRepository(client, crud),
+		bureauRep:    repository.NewBureauRepository(client, crud),
+	}
+}
+
+// TestGetShiftCardsByUserAndDateAndWeather_SingleCardBatchesUserFetch は、
+// 6スロット連続の単一カードに対してメンバー取得クエリが1回のバッチにまとまることを検証する。
+// UsersByTimesへの期待値を1回しか登録しないため、スロットごとの個別呼び出しに戻る回帰があれば
+// 「unexpected call」で即座に失敗する。
+func TestGetShiftCardsByUserAndDateAndWeather_SingleCardBatchesUserFetch(t *testing.T) {
+	client, mock := newFakeDBClient(t)
+	defer client.CloseDB()
+	// endTime計算・前後判定・最終スロットeTime再計算がUsersByTimes呼び出しの前後に混在するため、
+	// 呼び出し順序ではなく発生回数を検証する
+	mock.MatchExpectationsInOrder(false)
+	uc := newFullShiftUseCase(client)
+
+	mock.ExpectQuery(`(?i)FROM grades`).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "grade", "created_at", "updated_at"}).
+			AddRow(1, "B4", fixedTestTime, fixedTestTime))
+	mock.ExpectQuery(`(?i)FROM bureaus`).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "bureau", "color", "created_at", "updated_at"}).
+			AddRow(1, "総務局", "#000", fixedTestTime, fixedTestTime))
+
+	shiftRows := sqlmock.NewRows(shiftCardCols)
+	for i, timeID := range []int{1, 2, 3, 4, 5, 6} {
+		shiftRows.AddRow(shiftCardDataRow(100+i, 10, 4, 43, 2, timeID, 1, "テスト1", "8:"+[]string{"00", "15", "30", "45"}[i%4])...)
+	}
+	mock.ExpectQuery(`(?i)FROM\s+"shifts"`).WillReturnRows(shiftRows)
+
+	// 6スロット中、time_id=1にAlice、time_id=3にBobがアサインされているケース
+	mock.ExpectQuery(`s\.time_id = ANY\(\$4\)`).
+		WithArgs("4", "43", "2", sqlmock.AnyArg(), "1").
+		WillReturnRows(sqlmock.NewRows([]string{"time_id", "id", "name", "mail", "grade_id", "department_id", "bureau_id", "role_id", "student_number", "tel", "created_at", "updated_at", "slack_user_id"}).
+			AddRow(userRow(1, 1, "Alice")...).
+			AddRow(userRow(3, 2, "Bob")...))
+
+	// 前後スロット(time_id=0, 7)は存在しない前提。endTime計算・前後判定・最終スロットのeTime再計算の
+	// 3回、いずれもtime_id=7のFindが呼ばれるが該当なしを返す
+	expectNoMoreTimes(mock, 3)
+
+	cards, err := uc.GetShiftCardsByUserAndDateAndWeather(context.Background(), "10", "2", "1")
+	require.NoError(t, err)
+	require.Len(t, cards, 1)
+
+	card := cards[0]
+	assert.Equal(t, "テスト1", card.TaskName)
+	require.Len(t, card.ShiftMembers, 6)
+	require.Len(t, card.ShiftMembers[0].Members, 1)
+	assert.Equal(t, "Alice", card.ShiftMembers[0].Members[0].Name)
+	assert.Equal(t, "B4", card.ShiftMembers[0].Members[0].Grade)
+	assert.Empty(t, card.ShiftMembers[1].Members)
+	require.Len(t, card.ShiftMembers[2].Members, 1)
+	assert.Equal(t, "Bob", card.ShiftMembers[2].Members[0].Name)
+	assert.Empty(t, card.BeforeMembers.Members)
+	assert.Empty(t, card.AfterMembers.Members)
+
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestGetShiftCardsByUserAndDateAndWeather_TwoTasksBatchPerCard は、2タスク(=2カード)の
+// リクエストでメンバー取得クエリがカードごとに1回(=合計2回)にとどまることを検証する。
+// taskGroupsはGoのmapで管理されており反復順が非決定的なため、MatchExpectationsInOrder(false)で
+// 順序に依存しない形にする。
+func TestGetShiftCardsByUserAndDateAndWeather_TwoTasksBatchPerCard(t *testing.T) {
+	client, mock := newFakeDBClient(t)
+	defer client.CloseDB()
+	mock.MatchExpectationsInOrder(false)
+	uc := newFullShiftUseCase(client)
+
+	mock.ExpectQuery(`(?i)FROM grades`).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "grade", "created_at", "updated_at"}).
+			AddRow(1, "B4", fixedTestTime, fixedTestTime))
+	mock.ExpectQuery(`(?i)FROM bureaus`).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "bureau", "color", "created_at", "updated_at"}).
+			AddRow(1, "総務局", "#000", fixedTestTime, fixedTestTime))
+
+	shiftRows := sqlmock.NewRows(shiftCardCols).
+		AddRow(shiftCardDataRow(200, 10, 4, 43, 2, 1, 1, "テスト1", "8:00")...).
+		AddRow(shiftCardDataRow(201, 10, 4, 43, 2, 2, 1, "テスト1", "8:15")...).
+		AddRow(shiftCardDataRow(210, 10, 5, 43, 2, 1, 1, "テスト2", "8:00")...).
+		AddRow(shiftCardDataRow(211, 10, 5, 43, 2, 2, 1, "テスト2", "8:15")...)
+	mock.ExpectQuery(`(?i)FROM\s+"shifts"`).WillReturnRows(shiftRows)
+
+	emptyUsersCols := []string{"time_id", "id", "name", "mail", "grade_id", "department_id", "bureau_id", "role_id", "student_number", "tel", "created_at", "updated_at", "slack_user_id"}
+	// task_id=4のカード用バッチ取得
+	mock.ExpectQuery(`s\.time_id = ANY\(\$4\)`).
+		WithArgs("4", "43", "2", sqlmock.AnyArg(), "1").
+		WillReturnRows(sqlmock.NewRows(emptyUsersCols).AddRow(userRow(1, 1, "Alice")...))
+	// task_id=5のカード用バッチ取得
+	mock.ExpectQuery(`s\.time_id = ANY\(\$4\)`).
+		WithArgs("5", "43", "2", sqlmock.AnyArg(), "1").
+		WillReturnRows(sqlmock.NewRows(emptyUsersCols).AddRow(userRow(1, 2, "Bob")...))
+
+	// 両カードとも time_id=1..2 で連続し、前スロット(0)は存在せず、後ろのFind(3)も該当なし。
+	// カードごとに3回(endTime/前後判定/最終スロットeTime再計算)、2カード分で合計6回
+	expectNoMoreTimes(mock, 6)
+
+	cards, err := uc.GetShiftCardsByUserAndDateAndWeather(context.Background(), "10", "2", "1")
+	require.NoError(t, err)
+	require.Len(t, cards, 2)
+
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestToShiftMembers_MapsGradeAndBureau(t *testing.T) {
+	uc := &shiftUseCase{}
+
+	users := []entity.User{
+		{Name: "Alice", GradeID: 1, BureauID: 1},
+		{Name: "Bob", GradeID: 2, BureauID: 2},
+	}
+	gradeMap := map[int]string{1: "B4", 2: "M1"}
+	bureauMap := map[int]string{1: "総務局", 2: "企画局"}
+
+	members := uc.toShiftMembers(users, gradeMap, bureauMap)
+
+	require.Len(t, members, 2)
+	assert.Equal(t, "Alice", members[0].Name)
+	assert.Equal(t, "B4", members[0].Grade)
+	assert.Equal(t, "総務局", members[0].Bureau)
+	assert.Equal(t, "Bob", members[1].Name)
+	assert.Equal(t, "M1", members[1].Grade)
+	assert.Equal(t, "企画局", members[1].Bureau)
+}


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
resolve #437

# 概要
`GET /shift-cards/users/:user_id/dates/:date_id/weathers/:weather_id`（モバイル「マイシフト」画面が使用）のカード生成で、`GetUsersByShift`が15分スロットごと・前後スロット分で繰り返し呼ばれていたのを、カード単位の1クエリバッチ取得に変更した。

- `ShiftRepository`に`UsersByTimes`を追加（`Users()`のJOIN形状＋`ANY($4)`配列パラメータ、`user_repository.go`の`FindByNames`と同じ考え方）
- usecaseに`getUsersByTimes`/`toShiftMembers`を追加し、`createShiftCardFromGroup`を再構成。グループ内の全time_id（本体スロット＋前後1枠）を先に集めて1回だけバッチ取得する
- `GetUsersByShift`自体・`ShowUsersByShift`エンドポイントは無変更（単一time_id版として引き続き使用されるため）
- `GetUsersByShift`が内部で発行していたyear/date/time/weatherの単票Find4本は、呼び出し元のいずれからも参照されていなかったため、新しいバッチ取得メソッドでは意図的に取得しない

# 背景（なぜ今このタイミングで対応するか）
2026-07-20の負荷試験（`hey -z 1m -c 400 -q 0.5`、目標約200 req/s）でこのエンドポイントが実測28.4 req/s・平均12.2秒・p95 18.8秒、HTTP 500が153件・タイムアウトが203件を記録し不合格となった。DBリーダーCPUが最大約90%まで上昇しており、45th開催（2026年9月上旬）を控えたデプロイ判断に直結する。

`docs/development/test-roadmap.md`はフェーズ2（repository層ゴールデンテスト、実DB統合）完了後にこの種のリファクタへ着手することを推奨しているが、フェーズ2は未着手（フェーズ1の割り振りが2026-07-23に出たばかり）。本番負荷試験が既に不合格となっている状況を踏まえ、本issueに限りフェーズ2を待たずに着手した。安全網としてgo-sqlmockによるクエリ回数アサーション＋既存CI（`go-test.yml`）で代替している。

なお本件は既存issue #247のセクション「1.2 ShiftCard関連のメンバー取得メソッドのN+1問題」と同じ関数群を扱うが、#247のその記述内容自体（`GetUsersByShift`内部の個別ユーザー取得、grade/bureauの個別取得）は既に別途解消済みだったため、今回の負荷試験で新たに見つかった「呼び出し回数」の問題として#437を切り出している（詳細はissue本文参照）。

# 画面スクリーンショット等
- 該当なし（バックエンドのみ）

# テスト項目
- [x] `cd api && go test ./... -count=1` がグリーン
- [x] `shift_usecase_shiftcards_sqlmock_test.go`: 単一カード(6スロット)でユーザー取得クエリが1回にまとまること
- [x] 同テスト: 2タスク2カードでもカードごとに1回（合計2回）にまとまること（`MatchExpectationsInOrder(false)`でmapの反復順に依存しない形）
- [x] レスポンス内容（ShiftMembers/BeforeMembers/AfterMembers）のアサーション
- [x] ローカルのdocker-compose環境（実Postgres）でシフトデータを投入し、修正前（`git stash`でリバート）と修正後でレスポンスJSONが完全に一致することを確認済み（air のホットリロードで両方の状態を実機確認）

# 備考
- 対応issue #437 は親issue #247のサブissue。issue #264（`notification_usecase.go`のprocessGroup、user/date/weatherバッチ化）とは別件
- 45th向けの再負荷試験（#434）はこのPRのマージ後、N+1修正版で再実施予定


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * シフトカード表示時のメンバー情報取得を効率化し、複数の時間枠をまとめて処理することで、表示速度と応答性を改善しました。
  * 前後の時間枠を含むメンバー情報が、より安定してカードへ反映されるようになりました。

* **テスト**
  * 複数時間枠、空の時間枠、複数カードでの表示など、主要なケースを検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->