### PR TITLE
fix: DB接続プールに上限を設定し高負荷時の500エラーを解消

### DIFF
--- a/api/lib/externals/db/db.go
+++ b/api/lib/externals/db/db.go
@@ -6,6 +6,7 @@ import (
 	_ "github.com/lib/pq"
 	// "github.com/joho/godotenv"
 	"os"
+	"time"
 
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
@@ -45,7 +46,14 @@ func ConnectMySQL() (client, error) {
 	if err != nil {
 		return client{}, err
 	}
-	
+
+	// 接続数の上限を設定（無制限のままだと高負荷時にPostgresのmax_connectionsを超過し、
+	// リクエストが500エラーで失敗する。ミニPC実測で400並列負荷時の500エラー率を
+	// 37.8%→0%に改善することを確認済み）
+	db.SetMaxOpenConns(20)
+	db.SetMaxIdleConns(20)
+	db.SetConnMaxLifetime(30 * time.Minute)
+
 	err = db.Ping()
 
 	if err != nil {


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
resolve #440

# 概要
`api/lib/externals/db/db.go`の`sql.Open`で作成する接続プールに`SetMaxOpenConns`/`SetMaxIdleConns`/`SetConnMaxLifetime`を設定し、上限を超えた分は待機させる形にする。無制限のままだと高負荷時にPostgresの`max_connections`を超過し、リクエストが500エラーで即座に失敗していた。

# 背景
インフラ班がSeeFT-stg環境（共有DB基盤）でpgbouncer（DB手前の接続プーラー）を導入したところ、500エラー率が改善することを確認した。ただしpgbouncerはインフラ側の設定であり、`docker-compose.yml`を使うローカル開発環境やCI環境（プーラーが存在しない）では同じ問題が再現し続ける。

これを踏まえ、pgbouncerなしのミニPC環境（`fix/kanba/437-shift-cards-n-plus-one`ブランチ）で本修正を検証したところ、400並列負荷時の500エラー率が**37.8%→0%**（12,000件全件成功）に改善することを実測で確認した。req/sはほぼ変化なし（196.3→195.67）で、レイテンシもp50 1.28秒〜p99 1.36秒という狭い範囲に収まった。アプリ側の対策だけで接続超過による500エラーを防げることが実証できたため、インフラ側の対策（pgbouncer）と独立に、コード側にも同様の安全策を入れる。

# 画面スクリーンショット等
- 該当なし（バックエンドのみ）

# テスト項目
- [x] `cd api && go test ./... -count=1` がグリーン
- [x] ミニPC環境（pgbouncerなし）で、修正前後の`hey -z 1m -c 400 -q 0.5`実測比較
  - 修正前: 196.3 req/s、500エラー率37.8%
  - 修正後: 195.67 req/s、500エラー率**0%**（12,000件全件成功）

# 備考
- 対応issue #440 は親issue #434（API負荷試験の事前調査結果と試験計画をドキュメント化する）のサブissue
- N+1修正（PR #438、issue #437）とは独立した変更（触るファイルが別）で、互いに依存しない
- 公式試験計画書（`docs/development/load-test-plan.md` 7章「issue 2」）で試験前修正の1つとして提案されていた項目


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * PostgreSQL接続プールの設定を最適化し、同時接続数とアイドル接続数の上限を20に設定しました。
  * 接続の最大有効期間を30分に設定し、接続管理の安定性を向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->