### PR TITLE
feat: formatTimeRange のゴールデンテスト  #422

### DIFF
--- a/api/lib/usecase/notification_usecase_test.go
+++ b/api/lib/usecase/notification_usecase_test.go
@@ -1,0 +1,69 @@
+package usecase
+
+import (
+	"testing"
+
+	"github.com/NUTFes/SeeFT/api/lib/entity" 
+)
+
+func Test_notificationUseCase_formatTimeRange(t *testing.T) {
+	type args struct {
+		timeMap      map[int]entity.Time
+		startTimeID  int
+		endTimeID    int
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "正常系: マップに存在するIDが正しくフォーマットされること",
+			args: args{
+				timeMap: map[int]entity.Time{
+					1: {Time: "10:00"},
+					3: {Time: "12:00"}, // endTimeID(2) + 1 = 3 の場所
+				},
+				startTimeID: 1,
+				endTimeID:   2,
+			},
+			want: "10:00 〜 12:00",
+		},
+		{
+			name: "正常系: 終了ID+1がマップに存在しない場合、0:00にフォールバックすること",
+			args: args{
+				timeMap: map[int]entity.Time{
+					1: {Time: "23:00"},
+					// ID: 3 (2+1) が存在しない
+				},
+				startTimeID: 1,
+				endTimeID:   2,
+			},
+			want: "23:00 〜 0:00",
+		},
+		{
+			name: "要判断: 開始IDがマップに存在しない場合、開始時刻が空文字になる（非対称な挙動: issue #418）",
+			args: args{
+				timeMap: map[int]entity.Time{
+					3: {Time: "12:00"},
+					// ID: 1 が存在しない
+				},
+				startTimeID: 1,
+				endTimeID:   2,
+			},
+			want: " 〜 12:00", // 開始側が空文字のため、先頭にスペースが残る現状の挙動
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// レシーバはフィールドを参照しない純関数なのでゼロ値で初期化
+			n := &notificationUseCase{}
+			
+			got := n.formatTimeRange(tt.args.timeMap, tt.args.startTimeID, tt.args.endTimeID)
+			if got != tt.want {
+				t.Errorf("formatTimeRange() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/api/lib/usecase/notification_usecase_test.go
+++ b/api/lib/usecase/notification_usecase_test.go
@@ -3,64 +3,97 @@ package usecase
 import (
 	"testing"
 
-	"github.com/NUTFes/SeeFT/api/lib/entity" 
+	"github.com/NUTFes/SeeFT/api/lib/entity"
 )
 
 func Test_notificationUseCase_formatTimeRange(t *testing.T) {
-	type args struct {
-		timeMap      map[int]entity.Time
-		startTimeID  int
-		endTimeID    int
-	}
+	// テスト対象の構造体をゼロ値で生成
+	n := &notificationUseCase{}
+
 	tests := []struct {
-		name string
-		args args
-		want string
+		name        string
+		timeMap     map[int]entity.Time
+		startTimeID int
+		endTimeID   int
+		want        string
 	}{
 		{
-			name: "正常系: マップに存在するIDが正しくフォーマットされること",
-			args: args{
-				timeMap: map[int]entity.Time{
-					1: {Time: "10:00"},
-					3: {Time: "12:00"}, // endTimeID(2) + 1 = 3 の場所
-				},
-				startTimeID: 1,
-				endTimeID:   2,
+			name: "正常系: 連続スロット範囲のフォーマット",
+			timeMap: map[int]entity.Time{
+				1: {Time: "9:00"},
+				2: {Time: "10:00"},
+				3: {Time: "11:00"},
 			},
-			want: "10:00 〜 12:00",
+			startTimeID: 1,
+			endTimeID:   2,
+			want:        "9:00 〜 11:00",
 		},
 		{
-			name: "正常系: 終了ID+1がマップに存在しない場合、0:00にフォールバックすること",
-			args: args{
-				timeMap: map[int]entity.Time{
-					1: {Time: "23:00"},
-					// ID: 3 (2+1) が存在しない
-				},
-				startTimeID: 1,
-				endTimeID:   2,
+			name: "正常系: 同一スロット指定（実際の呼び出し形態）",
+			timeMap: map[int]entity.Time{
+				5: {Time: "13:00"},
+				6: {Time: "14:00"},
 			},
-			want: "23:00 〜 0:00",
+			startTimeID: 5,
+			endTimeID:   5,
+			want:        "13:00 〜 14:00",
 		},
 		{
-			name: "要判断: 開始IDがマップに存在しない場合、開始時刻が空文字になる（非対称な挙動: issue #418）",
-			args: args{
-				timeMap: map[int]entity.Time{
-					3: {Time: "12:00"},
-					// ID: 1 が存在しない
-				},
-				startTimeID: 1,
-				endTimeID:   2,
+			name:        "境界値: 最終スロットで次スロットが無い（要素1個のマップ）",
+			timeMap:     map[int]entity.Time{10: {Time: "22:00"}},
+			startTimeID: 10,
+			endTimeID:   10,
+			want:        "22:00 〜 0:00",
+		},
+		{
+			name:        "境界値: nil マップとゼロ値 ID",
+			timeMap:     nil,
+			startTimeID: 0,
+			endTimeID:   0,
+			want:        " 〜 0:00",
+		},
+		{
+	
+			name:        "要判断: startTimeID がマップに存在しない（非対称な挙動: issue #）",
+			timeMap:     map[int]entity.Time{2: {Time: "10:00"}},
+			startTimeID: 5,
+			endTimeID:   1,
+			want:        " 〜 10:00",
+		},
+		{
+			name: "境界値: 次スロットは存在するが Time フィールドがゼロ値（空文字）",
+			timeMap: map[int]entity.Time{
+				1: {Time: "9:00"},
+				2: {},
 			},
-			want: " 〜 12:00", // 開始側が空文字のため、先頭にスペースが残る現状の挙動
+			startTimeID: 1,
+			endTimeID:   1,
+			want:        "9:00 〜 ",
+		},
+		{
+			name:        "異常系: 負の ID（endTimeID+1 の算術で key 0 を参照）",
+			timeMap:     map[int]entity.Time{0: {Time: "8:00"}},
+			startTimeID: -1,
+			endTimeID:   -1,
+			want:        " 〜 8:00",
+		},
+		{
+			name: "異常系: 逆転範囲（startTimeID > endTimeID）",
+			timeMap: map[int]entity.Time{
+				1: {Time: "9:00"},
+				2: {Time: "10:00"},
+				3: {Time: "11:00"},
+				4: {Time: "12:00"},
+			},
+			startTimeID: 3,
+			endTimeID:   1,
+			want:        "11:00 〜 10:00",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// レシーバはフィールドを参照しない純関数なのでゼロ値で初期化
-			n := &notificationUseCase{}
-			
-			got := n.formatTimeRange(tt.args.timeMap, tt.args.startTimeID, tt.args.endTimeID)
+			got := n.formatTimeRange(tt.timeMap, tt.startTimeID, tt.endTimeID)
 			if got != tt.want {
 				t.Errorf("formatTimeRange() = %v, want %v", got, tt.want)
 			}


### PR DESCRIPTION
#422 `formatTimeRange` のゴールデンテスト（データ駆動テスト）を追加しました。
* 仕様の要判断ケースについて、まずはテストコードのロジックが正しいか先行してレビューをお願いするためのPRです。

<!-- 対応したIssue番号を記載 -->
resolve #422

# 概要
テストロードマップ　フェーズの1部として、formatTimeRange (api/lib/usecase/notification_usecase.go:359)にゴールテストを実行しました。

# テスト項目
-設計書の８ケースがテーブル駆動テストとして適切に実装され、`go test`でgreenになること。
-要件判断1件(`endTimeD+1`が`timeMap`にない場合は`0:00`にフォールバックする一方、`startTimeID側には同じフォールバック画なく空文字になる非対称な挙動)について、現状の挙動をそのまま期待値としたテストが書かれていること。
-ファイル配置・命名
(`notification_usecase_test.go`、対象と同じパッケージ)が、お手本PR＃419の規約に従っていること。

# 備考
‐本機能に関わる要判断ケース(現状の挙動をそのまま期待値とした部分)については、本PRマージ後に別途個別issueに切り出して対応予定です([用判断]compareTimeStrings:異常な時刻文字列入力時の挙動＃418と同じ形式を想定)。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * 通知時刻範囲の表示について、連続範囲、同一スロット、最終スロット、空データ、無効なID、空時刻、負のID、逆転範囲などのケースを追加検証しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->